### PR TITLE
Mathlib Vectors

### DIFF
--- a/code/krepel/math/math.d
+++ b/code/krepel/math/math.d
@@ -1,0 +1,9 @@
+module krepel.math.math;
+
+import std.math;
+
+float Sqrt(float value)
+{
+  // TODO replace with own (opcode?)
+  return std.math.sqrt(value);
+}

--- a/code/krepel/math/math.d
+++ b/code/krepel/math/math.d
@@ -5,6 +5,7 @@ import krepel.algorithm.comparison;
 
 @safe:
 @nogc:
+nothrow:
 
 /// Returns the square root of the given value
 float Sqrt(float value)
@@ -24,7 +25,7 @@ float Abs(float value)
 bool IsNaN(float value)
 {
   bool result;
-  asm @nogc @safe
+  asm @nogc @safe nothrow
   {
     fld value; // Load value to float stack ST(0)
     ftst; // Compare ST(0) with 0.0

--- a/code/krepel/math/math.d
+++ b/code/krepel/math/math.d
@@ -1,11 +1,18 @@
 module krepel.math.math;
 
 import std.math;
+import krepel.algorithm.comparison;
 
 float Sqrt(float value)
 {
   // TODO replace with own (opcode?)
   return std.math.sqrt(value);
+}
+
+float Abs(float value)
+{
+  // TODO replace with own (opcode?)
+  return std.math.abs(value);
 }
 
 bool IsNaN(float value)
@@ -26,7 +33,40 @@ bool IsNaN(float value)
   return !result;
 }
 
-// NaN Test
+/// Checks if a and b are equals with respect to some epsilon
+/// Epsilon gets scaled by the bigger of the two values to compare
+/// to compensate the reduced precision when using higher magnitudes
+bool NearlyEquals(float a, float b, float epsilon = 1.0e-4f)
+{
+  // Scale epsilon along the magnitude of the bigger of the two.
+  // This way we compoensate the reduced precision on bigger values.
+  return Abs(a - b) < Max(epsilon, (epsilon * Max(Abs(a), Abs(b))));
+}
+
+/// Nearly Equals
+unittest
+{
+  float a = 1.0f;
+  float b = 1.0f + 1.0e-5f;
+  float c = 10.0f;
+
+  float d = 1e10f;
+  // Default epsilon tolerates precision within 4 decimal points,
+  // so values are marked as different when they differ by 1e6f, when the order of magnitude is as 1e10f (10-4=6)
+  // A difference of 1e5f should be equal;
+  float e = 1e10f + 1e5f;
+  float f = 1e11f;
+  float g = 1e10f + 1e6f;
+
+  assert(NearlyEquals(a,b));
+  assert(!NearlyEquals(a,c));
+
+  assert(NearlyEquals(d,e));
+  assert(!NearlyEquals(d,f));
+  assert(!NearlyEquals(d,g));
+}
+
+/// NaN Test
 unittest
 {
   float f;

--- a/code/krepel/math/math.d
+++ b/code/krepel/math/math.d
@@ -3,6 +3,9 @@ module krepel.math.math;
 import std.math;
 import krepel.algorithm.comparison;
 
+@safe:
+@nogc:
+
 float Sqrt(float value)
 {
   // TODO replace with own (opcode?)
@@ -18,7 +21,7 @@ float Abs(float value)
 bool IsNaN(float value)
 {
   bool result;
-  asm
+  asm @nogc @safe
   {
     fld value; // Load value to float stack ST(0)
     ftst; // Compare ST(0) with 0.0

--- a/code/krepel/math/math.d
+++ b/code/krepel/math/math.d
@@ -6,18 +6,21 @@ import krepel.algorithm.comparison;
 @safe:
 @nogc:
 
+/// Returns the square root of the given value
 float Sqrt(float value)
 {
   // TODO replace with own (opcode?)
   return std.math.sqrt(value);
 }
 
+/// Returns the absolute value (the positive value)
 float Abs(float value)
 {
   // TODO replace with own (opcode?)
   return std.math.abs(value);
 }
 
+/// Checks if the given float value is QNaN
 bool IsNaN(float value)
 {
   bool result;

--- a/code/krepel/math/math.d
+++ b/code/krepel/math/math.d
@@ -7,3 +7,30 @@ float Sqrt(float value)
   // TODO replace with own (opcode?)
   return std.math.sqrt(value);
 }
+
+bool IsNaN(float value)
+{
+  bool result;
+  asm
+  {
+    fld value; // Load value to float stack ST(0)
+    ftst; // Compare ST(0) with 0.0
+    fstsw AX; // Write FPU Status Register to AX (16 Bit)
+    and AX, 0x4500; // Filter interesting bits (C0 C2 C3)
+    cmp AX, 0x4500; // Check if C0 C2 and C3 are set
+    lahf; // Load result of cmp into AH
+    and AH, 0x41; // Filter intereseting bits (CF, ZF)
+    xor AH, 0x40; // Check if ZF is set and CF is zero.
+    mov result, AH; // Write result into bool variable
+  }
+  return !result;
+}
+
+// NaN Test
+unittest
+{
+  float f;
+  float correct =1.0f;
+  assert(IsNaN(f));
+  assert(!IsNaN(correct));
+}

--- a/code/krepel/math/math.d
+++ b/code/krepel/math/math.d
@@ -7,27 +7,27 @@ import krepel.algorithm.comparison;
 @nogc:
 nothrow:
 
-/// Returns the square root of the given value
-float Sqrt(float value)
+/// Returns the square root of the given Value
+float Sqrt(float Value)
 {
   // TODO replace with own (opcode?)
-  return std.math.sqrt(value);
+  return std.math.sqrt(Value);
 }
 
-/// Returns the absolute value (the positive value)
-float Abs(float value)
+/// Returns the absolute Value (the positive Value)
+float Abs(float Value)
 {
   // TODO replace with own (opcode?)
-  return std.math.abs(value);
+  return std.math.abs(Value);
 }
 
-/// Checks if the given float value is QNaN
-bool IsNaN(float value)
+/// Checks if the given float Value is QNaN
+bool IsNaN(float Value)
 {
-  bool result;
+  bool Result;
   asm @nogc @safe nothrow
   {
-    fld value; // Load value to float stack ST(0)
+    fld Value; // Load Value to float stack ST(0)
     ftst; // Compare ST(0) with 0.0
     fstsw AX; // Write FPU Status Register to AX (16 Bit)
     and AX, 0x4500; // Filter interesting bits (C0 C2 C3)
@@ -35,49 +35,49 @@ bool IsNaN(float value)
     lahf; // Load result of cmp into AH
     and AH, 0x41; // Filter intereseting bits (CF, ZF)
     xor AH, 0x40; // Check if ZF is set and CF is zero.
-    mov result, AH; // Write result into bool variable
+    mov Result, AH; // Write result into bool variable
   }
-  return !result;
+  return !Result;
 }
 
 /// Checks if a and b are equals with respect to some epsilon
-/// Epsilon gets scaled by the bigger of the two values to compare
+/// Epsilon gets scaled by the bigger of the two Values to compare
 /// to compensate the reduced precision when using higher magnitudes
-bool NearlyEquals(float a, float b, float epsilon = 1.0e-4f)
+bool NearlyEquals(float A, float B, float Epsilon = 1.0e-4f)
 {
   // Scale epsilon along the magnitude of the bigger of the two.
-  // This way we compoensate the reduced precision on bigger values.
-  return Abs(a - b) < Max(epsilon, (epsilon * Max(Abs(a), Abs(b))));
+  // This way we compoensate the reduced precision on bigger Values.
+  return Abs(A - B) < Max(Epsilon, (Epsilon * Max(Abs(A), Abs(B))));
 }
 
 /// Nearly Equals
 unittest
 {
-  float a = 1.0f;
-  float b = 1.0f + 1.0e-5f;
-  float c = 10.0f;
+  float A = 1.0f;
+  float B = 1.0f + 1.0e-5f;
+  float C = 10.0f;
 
-  float d = 1e10f;
+  float D = 1e10f;
   // Default epsilon tolerates precision within 4 decimal points,
-  // so values are marked as different when they differ by 1e6f, when the order of magnitude is as 1e10f (10-4=6)
+  // so Values are marked as different when they differ by 1e6f, when the order of magnitude is as 1e10f (10-4=6)
   // A difference of 1e5f should be equal;
-  float e = 1e10f + 1e5f;
-  float f = 1e11f;
-  float g = 1e10f + 1e6f;
+  float E = 1e10f + 1e5f;
+  float F = 1e11f;
+  float G = 1e10f + 1e6f;
 
-  assert(NearlyEquals(a,b));
-  assert(!NearlyEquals(a,c));
+  assert(NearlyEquals(A,B));
+  assert(!NearlyEquals(A,C));
 
-  assert(NearlyEquals(d,e));
-  assert(!NearlyEquals(d,f));
-  assert(!NearlyEquals(d,g));
+  assert(NearlyEquals(D,E));
+  assert(!NearlyEquals(D,F));
+  assert(!NearlyEquals(D,G));
 }
 
 /// NaN Test
 unittest
 {
-  float f;
-  float correct =1.0f;
-  assert(IsNaN(f));
-  assert(!IsNaN(correct));
+  float F;
+  float Correct = 1.0f;
+  assert(IsNaN(F));
+  assert(!IsNaN(Correct));
 }

--- a/code/krepel/math/package.d
+++ b/code/krepel/math/package.d
@@ -2,3 +2,4 @@ module krepel.math;
 
 public import krepel.math.math;
 public import krepel.math.vector3;
+public import krepel.math.vector2;

--- a/code/krepel/math/package.d
+++ b/code/krepel/math/package.d
@@ -1,5 +1,6 @@
 module krepel.math;
 
 public import krepel.math.math;
+public import krepel.math.vector4;
 public import krepel.math.vector3;
 public import krepel.math.vector2;

--- a/code/krepel/math/package.d
+++ b/code/krepel/math/package.d
@@ -1,8 +1,4 @@
 module krepel.math;
 
-// NOTE(Manu): @Marvin
-// Create your <whatever>.d files within this folder and add the line `module
-// krepel.math.<whatever>` at the top of them. That line is optional but I
-// think it's nice to have it there. Within this file (math/package.d), you
-// can then add `public import krepel.math.<whatever>;`, so people only need
-// to say `import krepel.math;` and they will have everything they need.
+public import krepel.math.math;
+public import krepel.math.vector3;

--- a/code/krepel/math/vector2.d
+++ b/code/krepel/math/vector2.d
@@ -151,7 +151,7 @@ struct Vector2
     }
     else
     {
-      assert(false, "Operator " ~ op ~ " not implemented.");
+      static assert(false, "Operator " ~ op ~ " not implemented.");
     }
   }
 
@@ -172,7 +172,7 @@ struct Vector2
     }
     else
     {
-      assert(false, "Operator " ~ op ~ " not implemented.");
+      static assert(false, "Operator " ~ op ~ " not implemented.");
     }
   }
 
@@ -187,7 +187,7 @@ struct Vector2
     }
     else
     {
-      assert(false, "Operator " ~ op ~ " not implemented.");
+      static assert(false, "Operator " ~ op ~ " not implemented.");
     }
   }
 
@@ -202,7 +202,7 @@ struct Vector2
     }
     else
     {
-      assert(false, "Operator " ~ op ~ " not implemented.");
+      static assert(false, "Operator " ~ op ~ " not implemented.");
     }
   }
 

--- a/code/krepel/math/vector2.d
+++ b/code/krepel/math/vector2.d
@@ -242,7 +242,7 @@ struct Vector2
   }
 
   Vector3 opDispatch(string SwizzleString)() inout
-    if(SwizzleString.length == 3 || (SwizzleString.length == 4 && SwizzleString[0] == '_'))
+    if((SwizzleString.length == 3 && SwizzleString[0] != '_') || (SwizzleString.length == 4 && SwizzleString[0] == '_'))
   {
     // Special case for setting X to 0 (_0YZ)
     static if(SwizzleString.length == 4 && SwizzleString[0] == '_' && IsValidSwizzleString(SwizzleString[1..4]))
@@ -262,7 +262,7 @@ struct Vector2
   }
 
   Vector4 opDispatch(string SwizzleString)() inout
-    if(SwizzleString.length == 4 || (SwizzleString.length == 5 && SwizzleString[0] == '_'))
+    if((SwizzleString.length == 4 && SwizzleString[0] != '_') || (SwizzleString.length == 5 && SwizzleString[0] == '_'))
   {
     // Special case for setting X to 0 (_0YZ)
     static if(SwizzleString.length == 5 && SwizzleString[0] == '_' && IsValidSwizzleString(SwizzleString[1..5]))
@@ -460,6 +460,8 @@ struct Vector2
     assert(Vector2(1, 2).YX   == Vector2(2, 1));
     assert(Vector2(1, 2).XYX  == Vector3(1, 2, 1));
     assert(Vector2(1, 2).XYXY == Vector4(1, 2, 1, 2));
+    assert(Vector2(1, 2)._YX == Vector2(2, 1));
+    assert(Vector2(1, 2)._0X == Vector2(0, 1));
 
     static assert(!__traits(compiles, Vector2(1, 2).Foo), "Swizzling is only supposed to work with value members of " ~ Vector2.stringof ~ ".");
     static assert(!__traits(compiles, Vector2(1, 2).XXXXX), "Swizzling output dimension is limited to 4.");

--- a/code/krepel/math/vector2.d
+++ b/code/krepel/math/vector2.d
@@ -1,0 +1,388 @@
+module krepel.math.vector2;
+
+import krepel.math.math;
+import krepel.algorithm.comparison;
+import std.conv;
+
+@nogc:
+@safe:
+
+/// Calculates the Dot Product of the two vectors
+/// Input vectors will not be modified
+float Dot(Vector2 lhs, Vector2 rhs)
+{
+  float result = lhs | rhs;
+  return result;
+}
+
+/// Multiplies two vectors per component returning a new vector containing
+/// (lhs.X * rhs.X, lhs.Y * rhs.Y, lhs.Z * rhs.Z)
+/// Input vectors will not be modified
+Vector2 Mul(Vector2 lhs, Vector2 rhs)
+{
+  return lhs * rhs;
+}
+
+/// Calculates the squared length  of the given vector, which is the same as the dot product with the same vector
+/// Input vector will not be modified
+float LengthSquared(Vector2 vec)
+{
+  return vec | vec;
+}
+
+/// Calculates the 2D length of the Vector using the square root of the LengthSquared
+/// Input vector will not be modified
+float Length(Vector2 vec)
+{
+  return Sqrt(vec.LengthSquared());
+}
+
+/// Creates a copy of the vector, which is normalized in its length (has a length of 1.0)
+Vector2 NormalizedCopy(Vector2 vec)
+{
+  Vector2 copy = vec;
+  copy.Normalize();
+  return copy;
+}
+
+/// Projects a given vector onto a normal (normal needs to be normalized)
+/// Returns the projected vector, which will be a scaled version of the vector
+/// Input vectors will not be modified
+Vector2 ProjectOntoNormal(Vector2 vec, Vector2 normal)
+{
+  return normal * (vec | normal);
+}
+
+/// Projects a given vector on a plane, which has the given normal (normal needs to be normalized)
+/// Returns vector which resides on the plane spanned by the normal
+/// Input vector will not be modified
+Vector2 ProjectOntoPlane(Vector2 vec, Vector2 normal)
+{
+  return vec - vec.ProjectOntoNormal(normal);
+}
+
+/// Reflects a vector around a normal (normal needs to be normalized)
+/// Returns the reflected vector
+/// Input vectors will not be modified
+Vector2 ReflectVector(Vector2 vec, Vector2 normal)
+{
+  return vec - (2 * (vec | normal) * normal);
+}
+
+/// Checks if any component inside the vector is NaN.
+/// Input vector will not be modified
+bool ContainsNaN(Vector2 vec)
+{
+  return IsNaN(vec.X) || IsNaN(vec.Y);
+}
+
+/// Checks if two vectors are nearly equal (are equal with respect to a scaled epsilon)
+/// Input vectors will not be modified
+bool NearlyEquals(Vector2 a, Vector2 b, float epsilon = 1e-4f)
+{
+  return krepel.math.NearlyEquals(a.X, b.X, epsilon) &&
+         krepel.math.NearlyEquals(a.Y, b.Y, epsilon);
+}
+
+/// Returns a clamped copy of the given vector
+/// The retuned vector will be of size <= MaxSize
+/// Input vector will not be modified
+Vector2 ClampSize(Vector2 vec, float MaxSize)
+{
+  Vector2 normal = vec.NormalizedCopy();
+  return normal * Min(vec.Length(), MaxSize);
+}
+
+struct Vector2
+{
+  @safe:
+  @nogc:
+  union
+  {
+    struct
+    {
+      float X, Y;
+    }
+    float[2] Data;
+  }
+  this(float Value)
+  {
+    X = Value;
+    Y = Value;
+  }
+
+  this(float X, float Y)
+  {
+    this.X = X;
+    this.Y = Y;
+  }
+
+  /// Normalizes the vector (vector will have a length of 1.0)
+  void Normalize()
+  {
+    // Don't return result to avoid confusion with NormalizedCopy
+    // and stress that this operation modifies the vector on which it is called
+    float length = this.Length();
+    this /= length;
+  }
+
+  // Dot product
+  float opBinary(string op:"|")(Vector2 rhs)
+  {
+    return
+      X * rhs.X +
+      Y * rhs.Y;
+  }
+
+  Vector2 opOpAssign(string op)(float rhs)
+  {
+    static if(op == "*" || op == "/")
+    {
+      auto result = mixin("Vector2("~
+        "X" ~ op ~ "rhs,"
+        "Y" ~ op ~ "rhs)");
+      Data = result.Data;
+      return this;
+    }
+    else
+    {
+      assert(false, "Operator " ~ op ~ " not implemented.");
+    }
+  }
+
+  //const (char)[] ToString() const
+  //{
+  //  // TODO: More memory friendly (no GC) implementation?
+  //  return "{X:"~text(X)~", Y:"~text(Y)~", Z:"~text(Z)~"}";
+  //}
+
+  Vector2 opBinary(string op)(Vector2 rhs) inout
+  {
+    // Addition, subtraction, component wise multiplication
+    static if(op == "+" || op == "-" || op == "*")
+    {
+      return mixin("Vector2("~
+        "X" ~ op ~ "rhs.X,"
+        "Y" ~ op ~ "rhs.Y)");
+    }
+    else
+    {
+      assert(false, "Operator " ~ op ~ " not implemented.");
+    }
+  }
+
+  Vector2 opBinary(string op)(float rhs) inout
+  {
+    // Vector scaling
+    static if(op == "/" || op == "*")
+    {
+      return mixin("Vector2("~
+        "X" ~ op ~ "rhs,"
+        "Y" ~ op ~ "rhs)");
+    }
+    else
+    {
+      assert(false, "Operator " ~ op ~ " not implemented.");
+    }
+  }
+
+  Vector2 opBinaryRight(string op)(float rhs) inout
+  {
+    // Vector scaling
+    static if(op == "*")
+    {
+      return mixin("Vector2("~
+        "X" ~ op ~ "rhs,"
+        "Y" ~ op ~ "rhs)");
+    }
+    else
+    {
+      assert(false, "Operator " ~ op ~ " not implemented.");
+    }
+  }
+
+  Vector2 opDispatch(string s)() inout
+  {
+    // Special case for setting X to 0 (_0YZ)
+    static if(s.length == 3 && s[0] == '_')
+    {
+      return mixin(
+        "Vector2(" ~ s[1] ~","~
+        s[2] ~")");
+    }
+    else if(s.length == 2)
+    {
+      return mixin(
+        "Vector2(" ~ s[0] ~","~
+        s[1] ~")");
+    }
+  }
+
+  __gshared immutable UnitX           = Vector2(1,0);
+  __gshared immutable UnitY           = Vector2(0,1);
+  __gshared immutable UnitScaleVector = Vector2(1,1);
+  __gshared immutable ZeroVector      = Vector2(0,0);
+
+  // Initialization test
+  unittest
+  {
+    Vector2 v3 = Vector2(1,2);
+    assert(v3.X == 1);
+    assert(v3.Y == 2);
+    assert(v3.Data[0] == 1);
+    assert(v3.Data[1] == 2);
+
+    v3 = Vector2(5);
+    assert(v3.X == 5);
+    assert(v3.Y == 5);
+  }
+
+  // Addition test
+  unittest
+  {
+    Vector2 v1 = Vector2(1,2);
+    Vector2 v2 = Vector2(10,11);
+    auto v3 = v1 + v2;
+    assert(v3.X == 11);
+    assert(v3.Y == 13);
+  }
+
+  // Subtraction test
+  unittest
+  {
+    Vector2 v1 = Vector2(1,2);
+    Vector2 v2 = Vector2(10,11);
+    auto v3 = v1 - v2;
+    assert(v3.X == -9);
+    assert(v3.Y == -9);
+  }
+
+  // Float multiplication test
+  unittest
+  {
+    Vector2 v1 = Vector2(1,2) * 5;
+    Vector2 v2 = Vector2(1,2) * 5.0f;
+    assert(v1 == Vector2(5,10));
+    assert(v2 == Vector2(5,10));
+
+    v1 = 5 * Vector2(1,2);
+    v2 = 5.0f * Vector2(1,2);
+    assert(v1 == Vector2(5,10));
+    assert(v2 == Vector2(5,10));
+  }
+
+  // Float division test
+  unittest
+  {
+    Vector2 v1 = Vector2(5,10) / 5;
+    Vector2 v2 = Vector2(5,10) / 5.0f;
+    assert(v1 == Vector2(1,2));
+    assert(v2 == Vector2(1,2));
+
+    v1 = Vector2(5,10);
+    v2 = Vector2(5,10);
+    v1 /= 5;
+    v2 /= 5.0f;
+    assert(v1 == Vector2(1,2));
+    assert(v2 == Vector2(1,2));
+  }
+
+  /// Dot product test
+  unittest
+  {
+    Vector2 v1 = Vector2(1,2);
+    Vector2 v2 = Vector2(10,11);
+    auto v3 = v1 | v2;
+    assert(v3 == 10 + 22);
+    assert(v3 == v1.Dot(v2));
+  }
+
+  /// Component wise multiplication test
+  unittest
+  {
+    Vector2 v1 = Vector2(1,2);
+    Vector2 v2 = Vector2(10,11);
+    auto v3 = v1 * v2;
+    assert(v3.X == 10);
+    assert(v3.Y == 22);
+    assert(v3 == v1.Mul(v2));
+  }
+
+  /// Normalization
+  unittest
+  {
+    Vector2 vec = Vector2(1,1);
+    vec.Normalize();
+    float expected = 1.0f/Sqrt(2);
+    assert(vec == Vector2(expected, expected));
+
+    vec = Vector2(1,1);
+    auto normalized = vec.NormalizedCopy();
+    auto normalizedUFCS = NormalizedCopy(vec);
+    assert(vec == Vector2(1,1));
+    assert(normalized == Vector2(expected, expected));
+    assert(normalizedUFCS == Vector2(expected, expected));
+  }
+
+  /// Project Onto Normal
+  unittest
+  {
+    Vector2 normal = Vector2.UnitY;
+    Vector2 toProject = Vector2(1,1);
+
+    Vector2 projected = toProject.ProjectOntoNormal(normal);
+
+    assert(projected == Vector2(0,1));
+  }
+
+  /// Project Onto PLane
+  unittest
+  {
+    Vector2 normal = Vector2.UnitY;
+    Vector2 toProject = Vector2(1,1);
+
+    Vector2 projected = toProject.ProjectOntoPlane(normal);
+
+    assert(projected == Vector2(1,0));
+  }
+
+  /// Reflect Vector
+  unittest
+  {
+    Vector2 normal = Vector2(1,0);
+    Vector2 reflection = Vector2(-1,0);
+
+    Vector2 reflected = reflection.ReflectVector(normal);
+
+    assert(reflected == Vector2(1,0));
+  }
+
+  /// NearlyEquals
+  unittest
+  {
+    Vector2 a = Vector2(1,0);
+    Vector2 b = Vector2(1+1e-5f,-1e-6f);
+    Vector2 c = Vector2(1,10);
+    assert(NearlyEquals(a,b));
+    assert(!NearlyEquals(a,c));
+  }
+
+  /// Clamp Vector2
+  unittest
+  {
+    Vector2 vec = Vector2(100,0);
+    Vector2 clamped = vec.ClampSize(1);
+    assert(vec == Vector2(100,0));
+    assert(clamped == Vector2(1,0));
+  }
+
+  /// Dispatch test
+  unittest
+  {
+    Vector2 vec = Vector2(1,2);
+
+    Vector2 swizzled = vec.Y0;
+
+    assert(swizzled == Vector2(2,0));
+  }
+}

--- a/code/krepel/math/vector2.d
+++ b/code/krepel/math/vector2.d
@@ -10,90 +10,90 @@ import std.conv;
 @safe:
 nothrow:
 
-/// Calculates the Dot Product of the two vectors
-/// Input vectors will not be modified
-float Dot(Vector2 lhs, Vector2 rhs)
+/// Calculates the Dot Product of the two Vectors
+/// Input Vectors will not be modified
+float Dot(Vector2 Lhs, Vector2 Rhs)
 {
-  float result = lhs | rhs;
-  return result;
+  float Result = Lhs | Rhs;
+  return Result;
 }
 
-/// Multiplies two vectors per component returning a new vector containing
-/// (lhs.X * rhs.X, lhs.Y * rhs.Y, lhs.Z * rhs.Z)
-/// Input vectors will not be modified
-Vector2 Mul(Vector2 lhs, Vector2 rhs)
+/// Multiplies two Vectors per component returning a new Vector containing
+/// (Lhs.X * Rhs.X, Lhs.Y * Rhs.Y, Lhs.Z * Rhs.Z)
+/// Input Vectors will not be modified
+Vector2 Mul(Vector2 Lhs, Vector2 Rhs)
 {
-  return lhs * rhs;
+  return Lhs * Rhs;
 }
 
-/// Calculates the squared length  of the given vector, which is the same as the dot product with the same vector
-/// Input vector will not be modified
-float LengthSquared(Vector2 vec)
+/// Calculates the squared length  of the given Vector, which is the same as the dot product with the same Vector
+/// Input Vector will not be modified
+float LengthSquared(Vector2 Vec)
 {
-  return vec | vec;
+  return Vec | Vec;
 }
 
 /// Calculates the 2D length of the Vector using the square root of the LengthSquared
-/// Input vector will not be modified
-float Length(Vector2 vec)
+/// Input Vector will not be modified
+float Length(Vector2 Vec)
 {
-  return Sqrt(vec.LengthSquared());
+  return Sqrt(Vec.LengthSquared());
 }
 
-/// Creates a copy of the vector, which is normalized in its length (has a length of 1.0)
-Vector2 NormalizedCopy(Vector2 vec)
+/// Creates a copy of the Vector, which is Normalized in its length (has a length of 1.0)
+Vector2 NormalizedCopy(Vector2 Vec)
 {
-  Vector2 copy = vec;
-  copy.Normalize();
-  return copy;
+  Vector2 Copy = Vec;
+  Copy.Normalize();
+  return Copy;
 }
 
-/// Projects a given vector onto a normal (normal needs to be normalized)
-/// Returns the projected vector, which will be a scaled version of the vector
-/// Input vectors will not be modified
-Vector2 ProjectOntoNormal(Vector2 vec, Vector2 normal)
+/// Projects a given Vector onto a Normal (Normal needs to be Normalized)
+/// Returns the Projected Vector, which will be a scaled version of the Vector
+/// Input Vectors will not be modified
+Vector2 ProjectOntoNormal(Vector2 Vec, Vector2 Normal)
 {
-  return normal * (vec | normal);
+  return Normal * (Vec | Normal);
 }
 
-/// Projects a given vector on a plane, which has the given normal (normal needs to be normalized)
-/// Returns vector which resides on the plane spanned by the normal
-/// Input vector will not be modified
-Vector2 ProjectOntoPlane(Vector2 vec, Vector2 normal)
+/// Projects a given Vector on a plane, which has the given Normal (Normal needs to be Normalized)
+/// Returns Vector which resides on the plane spanned by the Normal
+/// Input Vector will not be modified
+Vector2 ProjectOntoPlane(Vector2 Vec, Vector2 Normal)
 {
-  return vec - vec.ProjectOntoNormal(normal);
+  return Vec - Vec.ProjectOntoNormal(Normal);
 }
 
-/// Reflects a vector around a normal (normal needs to be normalized)
-/// Returns the reflected vector
-/// Input vectors will not be modified
-Vector2 ReflectVector(Vector2 vec, Vector2 normal)
+/// Reflects a Vector around a Normal (Normal needs to be Normalized)
+/// Returns the reflected Vector
+/// Input Vectors will not be modified
+Vector2 ReflectVector(Vector2 Vec, Vector2 Normal)
 {
-  return vec - (2 * (vec | normal) * normal);
+  return Vec - (2 * (Vec | Normal) * Normal);
 }
 
-/// Checks if any component inside the vector is NaN.
-/// Input vector will not be modified
-bool ContainsNaN(Vector2 vec)
+/// Checks if any component inside the Vector is NaN.
+/// Input Vector will not be modified
+bool ContainsNaN(Vector2 Vec)
 {
-  return IsNaN(vec.X) || IsNaN(vec.Y);
+  return IsNaN(Vec.X) || IsNaN(Vec.Y);
 }
 
-/// Checks if two vectors are nearly equal (are equal with respect to a scaled epsilon)
-/// Input vectors will not be modified
-bool NearlyEquals(Vector2 a, Vector2 b, float epsilon = 1e-4f)
+/// Checks if two Vectors are nearly equal (are equal with respect to a scaled epsilon)
+/// Input Vectors will not be modified
+bool NearlyEquals(Vector2 A, Vector2 B, float Epsilon = 1e-4f)
 {
-  return krepel.math.NearlyEquals(a.X, b.X, epsilon) &&
-         krepel.math.NearlyEquals(a.Y, b.Y, epsilon);
+  return krepel.math.NearlyEquals(A.X, B.X, Epsilon) &&
+         krepel.math.NearlyEquals(A.Y, B.Y, Epsilon);
 }
 
-/// Returns a clamped copy of the given vector
-/// The retuned vector will be of size <= MaxSize
-/// Input vector will not be modified
-Vector2 ClampSize(Vector2 vec, float MaxSize)
+/// Returns a clamped copy of the given Vector
+/// The retuned Vector will be of size <= MaxSize
+/// Input Vector will not be modified
+Vector2 ClampSize(Vector2 Vec, float MaxSize)
 {
-  Vector2 normal = vec.NormalizedCopy();
-  return normal * Min(vec.Length(), MaxSize);
+  Vector2 Normal = Vec.NormalizedCopy();
+  return Normal * Min(Vec.Length(), MaxSize);
 }
 
 struct Vector2
@@ -122,36 +122,36 @@ struct Vector2
     this.Y = Y;
   }
 
-  /// Normalizes the vector (vector will have a length of 1.0)
+  /// Normalizes the Vector (Vector will have a length of 1.0)
   void Normalize()
   {
-    // Don't return result to avoid confusion with NormalizedCopy
-    // and stress that this operation modifies the vector on which it is called
-    float length = this.Length();
-    this /= length;
+    // Don't return Result to avoid confusion with NormalizedCopy
+    // and stress that this operation modifies the Vector on which it is called
+    float Length = this.Length();
+    this /= Length;
   }
 
   // Dot product
-  float opBinary(string op:"|")(Vector2 rhs)
+  float opBinary(string Operator:"|")(Vector2 Rhs)
   {
     return
-      X * rhs.X +
-      Y * rhs.Y;
+      X * Rhs.X +
+      Y * Rhs.Y;
   }
 
-  Vector2 opOpAssign(string op)(float rhs)
+  Vector2 opOpAssign(string Operator)(float Rhs)
   {
-    static if(op == "*" || op == "/")
+    static if(Operator == "*" || Operator == "/")
     {
-      auto result = mixin("Vector2("~
-        "X" ~ op ~ "rhs,"
-        "Y" ~ op ~ "rhs)");
-      Data = result.Data;
+      auto Result = mixin("Vector2("~
+        "X" ~ Operator ~ "Rhs,"
+        "Y" ~ Operator ~ "Rhs)");
+      Data = Result.Data;
       return this;
     }
     else
     {
-      static assert(false, "Operator " ~ op ~ " not implemented.");
+      static assert(false, "Operator " ~ Operator ~ " not implemented.");
     }
   }
 
@@ -161,48 +161,48 @@ struct Vector2
   //  return "{X:"~text(X)~", Y:"~text(Y)~", Z:"~text(Z)~"}";
   //}
 
-  Vector2 opBinary(string op)(Vector2 rhs) inout
+  Vector2 opBinary(string Operator)(Vector2 Rhs) inout
   {
     // Addition, subtraction, component wise multiplication
-    static if(op == "+" || op == "-" || op == "*")
+    static if(Operator == "+" || Operator == "-" || Operator == "*")
     {
       return mixin("Vector2("~
-        "X" ~ op ~ "rhs.X,"
-        "Y" ~ op ~ "rhs.Y)");
+        "X" ~ Operator ~ "Rhs.X,"
+        "Y" ~ Operator ~ "Rhs.Y)");
     }
     else
     {
-      static assert(false, "Operator " ~ op ~ " not implemented.");
+      static assert(false, "Operator " ~ Operator ~ " not implemented.");
     }
   }
 
-  Vector2 opBinary(string op)(float rhs) inout
+  Vector2 opBinary(string Operator)(float Rhs) inout
   {
     // Vector scaling
-    static if(op == "/" || op == "*")
+    static if(Operator == "/" || Operator == "*")
     {
       return mixin("Vector2("~
-        "X" ~ op ~ "rhs,"
-        "Y" ~ op ~ "rhs)");
+        "X" ~ Operator ~ "Rhs,"
+        "Y" ~ Operator ~ "Rhs)");
     }
     else
     {
-      static assert(false, "Operator " ~ op ~ " not implemented.");
+      static assert(false, "Operator " ~ Operator ~ " not implemented.");
     }
   }
 
-  Vector2 opBinaryRight(string op)(float rhs) inout
+  Vector2 opBinaryRight(string Operator)(float Rhs) inout
   {
     // Vector scaling
-    static if(op == "*")
+    static if(Operator == "*")
     {
       return mixin("Vector2("~
-        "X" ~ op ~ "rhs,"
-        "Y" ~ op ~ "rhs)");
+        "X" ~ Operator ~ "Rhs,"
+        "Y" ~ Operator ~ "Rhs)");
     }
     else
     {
-      static assert(false, "Operator " ~ op ~ " not implemented.");
+      static assert(false, "Operator " ~ Operator ~ " not implemented.");
     }
   }
 
@@ -291,164 +291,164 @@ struct Vector2
   // Initialization test
   unittest
   {
-    Vector2 v3 = Vector2(1,2);
-    assert(v3.X == 1);
-    assert(v3.Y == 2);
-    assert(v3.Data[0] == 1);
-    assert(v3.Data[1] == 2);
+    Vector2 V3 = Vector2(1,2);
+    assert(V3.X == 1);
+    assert(V3.Y == 2);
+    assert(V3.Data[0] == 1);
+    assert(V3.Data[1] == 2);
 
-    v3 = Vector2(5);
-    assert(v3.X == 5);
-    assert(v3.Y == 5);
+    V3 = Vector2(5);
+    assert(V3.X == 5);
+    assert(V3.Y == 5);
   }
 
   // Addition test
   unittest
   {
-    Vector2 v1 = Vector2(1,2);
-    Vector2 v2 = Vector2(10,11);
-    auto v3 = v1 + v2;
-    assert(v3.X == 11);
-    assert(v3.Y == 13);
+    Vector2 V1 = Vector2(1,2);
+    Vector2 V2 = Vector2(10,11);
+    auto V3 = V1 + V2;
+    assert(V3.X == 11);
+    assert(V3.Y == 13);
   }
 
   // Subtraction test
   unittest
   {
-    Vector2 v1 = Vector2(1,2);
-    Vector2 v2 = Vector2(10,11);
-    auto v3 = v1 - v2;
-    assert(v3.X == -9);
-    assert(v3.Y == -9);
+    Vector2 V1 = Vector2(1,2);
+    Vector2 V2 = Vector2(10,11);
+    auto V3 = V1 - V2;
+    assert(V3.X == -9);
+    assert(V3.Y == -9);
   }
 
   // Float multiplication test
   unittest
   {
-    Vector2 v1 = Vector2(1,2) * 5;
-    Vector2 v2 = Vector2(1,2) * 5.0f;
-    assert(v1 == Vector2(5,10));
-    assert(v2 == Vector2(5,10));
+    Vector2 V1 = Vector2(1,2) * 5;
+    Vector2 V2 = Vector2(1,2) * 5.0f;
+    assert(V1 == Vector2(5,10));
+    assert(V2 == Vector2(5,10));
 
-    v1 = 5 * Vector2(1,2);
-    v2 = 5.0f * Vector2(1,2);
-    assert(v1 == Vector2(5,10));
-    assert(v2 == Vector2(5,10));
+    V1 = 5 * Vector2(1,2);
+    V2 = 5.0f * Vector2(1,2);
+    assert(V1 == Vector2(5,10));
+    assert(V2 == Vector2(5,10));
   }
 
   // Float division test
   unittest
   {
-    Vector2 v1 = Vector2(5,10) / 5;
-    Vector2 v2 = Vector2(5,10) / 5.0f;
-    assert(v1 == Vector2(1,2));
-    assert(v2 == Vector2(1,2));
+    Vector2 V1 = Vector2(5,10) / 5;
+    Vector2 V2 = Vector2(5,10) / 5.0f;
+    assert(V1 == Vector2(1,2));
+    assert(V2 == Vector2(1,2));
 
-    v1 = Vector2(5,10);
-    v2 = Vector2(5,10);
-    v1 /= 5;
-    v2 /= 5.0f;
-    assert(v1 == Vector2(1,2));
-    assert(v2 == Vector2(1,2));
+    V1 = Vector2(5,10);
+    V2 = Vector2(5,10);
+    V1 /= 5;
+    V2 /= 5.0f;
+    assert(V1 == Vector2(1,2));
+    assert(V2 == Vector2(1,2));
   }
 
   /// Dot product test
   unittest
   {
-    Vector2 v1 = Vector2(1,2);
-    Vector2 v2 = Vector2(10,11);
-    auto v3 = v1 | v2;
-    assert(v3 == 10 + 22);
-    assert(v3 == v1.Dot(v2));
+    Vector2 V1 = Vector2(1,2);
+    Vector2 V2 = Vector2(10,11);
+    auto V3 = V1 | V2;
+    assert(V3 == 10 + 22);
+    assert(V3 == V1.Dot(V2));
   }
 
   /// Component wise multiplication test
   unittest
   {
-    Vector2 v1 = Vector2(1,2);
-    Vector2 v2 = Vector2(10,11);
-    auto v3 = v1 * v2;
-    assert(v3.X == 10);
-    assert(v3.Y == 22);
-    assert(v3 == v1.Mul(v2));
+    Vector2 V1 = Vector2(1,2);
+    Vector2 V2 = Vector2(10,11);
+    auto V3 = V1 * V2;
+    assert(V3.X == 10);
+    assert(V3.Y == 22);
+    assert(V3 == V1.Mul(V2));
   }
 
   /// Normalization
   unittest
   {
-    Vector2 vec = Vector2(1,1);
-    vec.Normalize();
-    float expected = 1.0f/Sqrt(2);
-    assert(vec == Vector2(expected, expected));
+    Vector2 Vec = Vector2(1,1);
+    Vec.Normalize();
+    float Expected = 1.0f/Sqrt(2);
+    assert(Vec == Vector2(Expected, Expected));
 
-    vec = Vector2(1,1);
-    auto normalized = vec.NormalizedCopy();
-    auto normalizedUFCS = NormalizedCopy(vec);
-    assert(vec == Vector2(1,1));
-    assert(normalized == Vector2(expected, expected));
-    assert(normalizedUFCS == Vector2(expected, expected));
+    Vec = Vector2(1,1);
+    auto Normalized = Vec.NormalizedCopy();
+    auto NormalizedUFCS = NormalizedCopy(Vec);
+    assert(Vec == Vector2(1,1));
+    assert(Normalized == Vector2(Expected, Expected));
+    assert(NormalizedUFCS == Vector2(Expected, Expected));
   }
 
   /// Project Onto Normal
   unittest
   {
-    Vector2 normal = Vector2.UnitY;
-    Vector2 toProject = Vector2(1,1);
+    Vector2 Normal = Vector2.UnitY;
+    Vector2 ToProject = Vector2(1,1);
 
-    Vector2 projected = toProject.ProjectOntoNormal(normal);
+    Vector2 Projected = ToProject.ProjectOntoNormal(Normal);
 
-    assert(projected == Vector2(0,1));
+    assert(Projected == Vector2(0,1));
   }
 
   /// Project Onto PLane
   unittest
   {
-    Vector2 normal = Vector2.UnitY;
-    Vector2 toProject = Vector2(1,1);
+    Vector2 Normal = Vector2.UnitY;
+    Vector2 ToProject = Vector2(1,1);
 
-    Vector2 projected = toProject.ProjectOntoPlane(normal);
+    Vector2 Projected = ToProject.ProjectOntoPlane(Normal);
 
-    assert(projected == Vector2(1,0));
+    assert(Projected == Vector2(1,0));
   }
 
   /// Reflect Vector
   unittest
   {
-    Vector2 normal = Vector2(1,0);
-    Vector2 reflection = Vector2(-1,0);
+    Vector2 Normal = Vector2(1,0);
+    Vector2 Reflection = Vector2(-1,0);
 
-    Vector2 reflected = reflection.ReflectVector(normal);
+    Vector2 Reflected = Reflection.ReflectVector(Normal);
 
-    assert(reflected == Vector2(1,0));
+    assert(Reflected == Vector2(1,0));
   }
 
   /// NearlyEquals
   unittest
   {
-    Vector2 a = Vector2(1,0);
-    Vector2 b = Vector2(1+1e-5f,-1e-6f);
-    Vector2 c = Vector2(1,10);
-    assert(NearlyEquals(a,b));
-    assert(!NearlyEquals(a,c));
+    Vector2 A = Vector2(1,0);
+    Vector2 B = Vector2(1+1e-5f,-1e-6f);
+    Vector2 C = Vector2(1,10);
+    assert(NearlyEquals(A,B));
+    assert(!NearlyEquals(A,C));
   }
 
   /// Clamp Vector2
   unittest
   {
-    Vector2 vec = Vector2(100,0);
-    Vector2 clamped = vec.ClampSize(1);
-    assert(vec == Vector2(100,0));
-    assert(clamped == Vector2(1,0));
+    Vector2 Vec = Vector2(100,0);
+    Vector2 Clamped = Vec.ClampSize(1);
+    assert(Vec == Vector2(100,0));
+    assert(Clamped == Vector2(1,0));
   }
 
   /// Dispatch test
   unittest
   {
-    Vector2 vec = Vector2(1,2);
+    Vector2 Vec = Vector2(1,2);
 
-    Vector2 swizzled = vec.Y0;
+    Vector2 Swizzled = Vec.Y0;
 
-    assert(swizzled == Vector2(2,0));
+    assert(Swizzled == Vector2(2,0));
   }
 
   // Vector2

--- a/code/krepel/math/vector3.d
+++ b/code/krepel/math/vector3.d
@@ -28,6 +28,7 @@ float Length(Vector3 vec)
   return Sqrt(vec.LengthSquared());
 }
 
+
 struct Vector3
 {
   union
@@ -51,6 +52,12 @@ struct Vector3
     this.Z = Z;
   }
 
+  void Normalize()
+  {
+    float length = this.Length();
+    this /= length;
+  }
+
   // Dot product
   float opBinary(string op:"|")(Vector3 rhs)
   {
@@ -58,6 +65,23 @@ struct Vector3
       X * rhs.X +
       Y * rhs.Y +
       Z * rhs.Z;
+  }
+
+  Vector3 opOpAssign(string op)(float rhs)
+  {
+    static if(op == "*" || op == "/")
+    {
+      auto result = mixin("Vector3("~
+        "X" ~ op ~ "rhs,"
+        "Y" ~ op ~ "rhs,"
+        "Z" ~ op ~ "rhs)");
+      Data = result.Data;
+      return this;
+    }
+    else
+    {
+      assert(false, "Operator " ~ op ~ " not implemented.");
+    }
   }
 
   Vector3 opBinary(string op)(Vector3 rhs)
@@ -179,6 +203,13 @@ struct Vector3
   {
     Vector3 v1 = Vector3(5,10,15) / 5;
     Vector3 v2 = Vector3(5,10,15) / 5.0f;
+    assert(v1 == Vector3(1,2,3));
+    assert(v2 == Vector3(1,2,3));
+
+    v1 = Vector3(5,10,15);
+    v2 = Vector3(5,10,15);
+    v1 /= 5;
+    v2 /= 5.0f;
     assert(v1 == Vector3(1,2,3));
     assert(v2 == Vector3(1,2,3));
   }

--- a/code/krepel/math/vector3.d
+++ b/code/krepel/math/vector3.d
@@ -1,0 +1,222 @@
+module krepel.math.vector3;
+
+import krepel.math.math;
+
+float Dot(Vector3 lhs, Vector3 rhs)
+{
+  float result = lhs | rhs;
+  return result;
+}
+
+Vector3 Mul(Vector3 lhs, Vector3 rhs)
+{
+  return lhs * rhs;
+}
+
+Vector3 Cross(Vector3 lhs, Vector3 rhs)
+{
+  return lhs ^ rhs;
+}
+
+float LengthSquared(Vector3 vec)
+{
+  return vec | vec;
+}
+
+float Length(Vector3 vec)
+{
+  return Sqrt(vec.LengthSquared());
+}
+
+struct Vector3
+{
+  union
+  {
+    struct{
+      float X, Y, Z;
+    }
+    float[3] Data;
+  }
+  this(float Value)
+  {
+    X = Value;
+    Y = Value;
+    Z = Value;
+  }
+
+  this(float X, float Y, float Z)
+  {
+    this.X = X;
+    this.Y = Y;
+    this.Z = Z;
+  }
+
+  // Dot product
+  float opBinary(string op:"|")(Vector3 rhs)
+  {
+    return
+      X * rhs.X +
+      Y * rhs.Y +
+      Z * rhs.Z;
+  }
+
+  Vector3 opBinary(string op)(Vector3 rhs)
+  {
+    // Addition, subtraction, component wise multiplication
+    static if(op == "+" || op == "-" || op == "*")
+    {
+      return mixin("Vector3("~
+        "X" ~ op ~ "rhs.X,"
+        "Y" ~ op ~ "rhs.Y,"
+        "Z" ~ op ~ "rhs.Z)");
+    }
+    // Cross Product
+    else if(op == "^")
+    {
+      return Vector3(
+        (Y * rhs.Z) - (Z * rhs.Y),
+        (Z * rhs.X) - (X * rhs.Z),
+        (X * rhs.Y) - (Y * rhs.X)
+      );
+    }
+    else
+    {
+      assert(false, "Operator " ~ op ~ " not implemented.");
+    }
+  }
+
+  Vector3 opBinary(string op)(float rhs)
+  {
+    // Vector scaling
+    static if(op == "/" || op == "*")
+    {
+      return mixin("Vector3("~
+        "X" ~ op ~ "rhs,"
+        "Y" ~ op ~ "rhs,"
+        "Z" ~ op ~ "rhs)");
+    }
+    else
+    {
+      assert(false, "Operator " ~ op ~ " not implemented.");
+    }
+  }
+
+  Vector3 opBinaryRight(string op)(float rhs)
+  {
+    // Vector scaling
+    static if(op == "*")
+    {
+      return mixin("Vector3("~
+        "X" ~ op ~ "rhs,"
+        "Y" ~ op ~ "rhs,"
+        "Z" ~ op ~ "rhs)");
+    }
+    else
+    {
+      assert(false, "Operator " ~ op ~ " not implemented.");
+    }
+  }
+
+  static Vector3 Forward = Vector3(1,0,0);
+  static Vector3 Right = Vector3(0,1,0);
+  static Vector3 Up = Vector3(0,0,1);
+
+  // Initialization test
+  unittest
+  {
+    Vector3 v3 = Vector3(1,2,3);
+    assert(v3.X == 1);
+    assert(v3.Y == 2);
+    assert(v3.Z == 3);
+    assert(v3.Data[0] == 1);
+    assert(v3.Data[1] == 2);
+    assert(v3.Data[2] == 3);
+
+    v3 = Vector3(5);
+    assert(v3.X == 5);
+    assert(v3.Y == 5);
+    assert(v3.Z == 5);
+  }
+
+  // Addition test
+  unittest
+  {
+    Vector3 v1 = Vector3(1,2,3);
+    Vector3 v2 = Vector3(10,11,12);
+    auto v3 = v1 + v2;
+    assert(v3.X == 11);
+    assert(v3.Y == 13);
+    assert(v3.Z == 15);
+  }
+
+  // Subtraction test
+  unittest
+  {
+    Vector3 v1 = Vector3(1,2,3);
+    Vector3 v2 = Vector3(10,11,12);
+    auto v3 = v1 - v2;
+    assert(v3.X == -9);
+    assert(v3.Y == -9);
+    assert(v3.Z == -9);
+  }
+
+  // Float multiplication test
+  unittest
+  {
+    Vector3 v1 = Vector3(1,2,3) * 5;
+    Vector3 v2 = Vector3(1,2,3) * 5.0f;
+    assert(v1 == Vector3(5,10,15));
+    assert(v2 == Vector3(5,10,15));
+
+    v1 = 5 * Vector3(1,2,3);
+    v2 = 5.0f * Vector3(1,2,3);
+    assert(v1 == Vector3(5,10,15));
+    assert(v2 == Vector3(5,10,15));
+  }
+
+  // Float division test
+  unittest
+  {
+    Vector3 v1 = Vector3(5,10,15) / 5;
+    Vector3 v2 = Vector3(5,10,15) / 5.0f;
+    assert(v1 == Vector3(1,2,3));
+    assert(v2 == Vector3(1,2,3));
+  }
+
+  /// Dot product test
+  unittest
+  {
+    Vector3 v1 = Vector3(1,2,3);
+    Vector3 v2 = Vector3(10,11,12);
+    auto v3 = v1 | v2;
+    assert(v3 == 10 + 22 + 36);
+    assert(v3 == v1.Dot(v2));
+  }
+
+  /// Component wise multiplication test
+  unittest
+  {
+    Vector3 v1 = Vector3(1,2,3);
+    Vector3 v2 = Vector3(10,11,12);
+    auto v3 = v1 * v2;
+    assert(v3.X == 10);
+    assert(v3.Y == 22);
+    assert(v3.Z == 36);
+    assert(v3 == v1.Mul(v2));
+  }
+
+  /// Cross Product
+  unittest
+  {
+    // Operator
+    auto vec = Vector3.Up ^ Vector3.Forward;
+    assert(vec == Vector3.Right);
+    // Function
+    assert(Cross(Vector3.Up, Vector3.Forward) == Vector3.Right);
+    Vector3 vec1 = Vector3.Up;
+    Vector3 vec2 = Vector3.Forward;
+    // UFCS
+    Vector3 vec3 = vec1.Cross(vec2);
+    assert(vec3 == Vector3.Right);
+  }
+}

--- a/code/krepel/math/vector3.d
+++ b/code/krepel/math/vector3.d
@@ -216,6 +216,14 @@ struct Vector3
     }
   }
 
+  Vector3 opDispatch(string s)() inout
+  {
+    return mixin(
+      "Vector3(" ~ (s[0] == 'O' ? '0' : s[0] ) ~","~
+      (s[1] == 'O' ? '0' : s[1] ) ~","~
+      (s[2] == 'O' ? '0' : s[2] ) ~")");
+  }
+
   __gshared immutable ForwardVector   = Vector3(1,0,0);
   __gshared immutable RightVector     = Vector3(0,1,0);
   __gshared immutable UpVector        = Vector3(0,0,1);
@@ -411,5 +419,14 @@ struct Vector3
     Vector3 vec = Vector3(0,1,1032094);
     assert(vec.Length2D() == 1);
     assert(vec.LengthSquared2D() == 1);
+  }
+
+  unittest
+  {
+    Vector3 vec = Vector3(1,2,3);
+
+    Vector3 swizzled = vec.ZOY;
+
+    assert(swizzled == Vector3(3,0,2));
   }
 }

--- a/code/krepel/math/vector3.d
+++ b/code/krepel/math/vector3.d
@@ -36,6 +36,16 @@ Vector3 NormalizedCopy(Vector3 vec)
   return copy;
 }
 
+Vector3 ProjectOntoNormal(Vector3 vec, Vector3 normal)
+{
+  return normal * (vec | normal);
+}
+
+Vector3 ProjectOntoPlane(Vector3 vec, Vector3 normal)
+{
+  return vec - vec.ProjectOntoNormal(normal);
+}
+
 
 struct Vector3
 {
@@ -269,7 +279,7 @@ struct Vector3
     assert(vec3 == Vector3.RightVector);
   }
 
-  // Normalization
+  /// Normalization
   unittest
   {
     Vector3 vec = Vector3(1,1,1);
@@ -283,5 +293,27 @@ struct Vector3
     assert(vec == Vector3(1,1,1));
     assert(normalized == Vector3(expected, expected, expected));
     assert(normalizedUFCS == Vector3(expected, expected, expected));
+  }
+
+  /// Project Onto Normal
+  unittest
+  {
+    Vector3 normal = Vector3.UpVector;
+    Vector3 toProject = Vector3(1,1,0.5f);
+
+    Vector3 projected = toProject.ProjectOntoNormal(normal);
+
+    assert(projected == Vector3(0,0,0.5f));
+  }
+
+  /// Project Onto PLane
+  unittest
+  {
+    Vector3 normal = Vector3.UpVector;
+    Vector3 toProject = Vector3(1,1,0.5f);
+
+    Vector3 projected = toProject.ProjectOntoPlane(normal);
+
+    assert(projected == Vector3(1,1,0));
   }
 }

--- a/code/krepel/math/vector3.d
+++ b/code/krepel/math/vector3.d
@@ -51,11 +51,17 @@ Vector3 ReflectVector(Vector3 vec, Vector3 normal)
   return vec - (2 * (vec | normal) * normal);
 }
 
+bool ContainsNaN(Vector3 vec)
+{
+  return IsNaN(vec.X) || IsNaN(vec.Y) || IsNaN(vec.Z);
+}
+
 struct Vector3
 {
   union
   {
-    struct{
+    struct
+    {
       float X, Y, Z;
     }
     float[3] Data;

--- a/code/krepel/math/vector3.d
+++ b/code/krepel/math/vector3.d
@@ -1,6 +1,7 @@
 module krepel.math.vector3;
 
 import krepel.math.math;
+import std.conv;
 
 float Dot(Vector3 lhs, Vector3 rhs)
 {
@@ -28,6 +29,13 @@ float Length(Vector3 vec)
   return Sqrt(vec.LengthSquared());
 }
 
+Vector3 NormalizedCopy(Vector3 vec)
+{
+  Vector3 copy = vec;
+  copy.Normalize();
+  return copy;
+}
+
 
 struct Vector3
 {
@@ -52,6 +60,8 @@ struct Vector3
     this.Z = Z;
   }
 
+  // Don't return result to avoid confusion with NormalizedCopy
+  // and stress that this operation modifies the vector on which it is called
   void Normalize()
   {
     float length = this.Length();
@@ -83,6 +93,12 @@ struct Vector3
       assert(false, "Operator " ~ op ~ " not implemented.");
     }
   }
+
+  //const (char)[] ToString() const
+  //{
+  //  // TODO: More memory friendly (no GC) implementation?
+  //  return "{X:"~text(X)~", Y:"~text(Y)~", Z:"~text(Z)~"}";
+  //}
 
   Vector3 opBinary(string op)(Vector3 rhs) inout
   {
@@ -251,5 +267,21 @@ struct Vector3
     // UFCS
     Vector3 vec3 = vec1.Cross(vec2);
     assert(vec3 == Vector3.RightVector);
+  }
+
+  // Normalization
+  unittest
+  {
+    Vector3 vec = Vector3(1,1,1);
+    vec.Normalize();
+    float expected = 1.0f/Sqrt(3);
+    assert(vec == Vector3(expected, expected, expected));
+
+    vec = Vector3(1,1,1);
+    auto normalized = vec.NormalizedCopy();
+    auto normalizedUFCS = NormalizedCopy(vec);
+    assert(vec == Vector3(1,1,1));
+    assert(normalized == Vector3(expected, expected, expected));
+    assert(normalizedUFCS == Vector3(expected, expected, expected));
   }
 }

--- a/code/krepel/math/vector3.d
+++ b/code/krepel/math/vector3.d
@@ -7,42 +7,58 @@ import std.conv;
 @nogc:
 @safe:
 
+/// Calculates the Dot Product of the two vectors
+/// Input vectors will not be modified
 float Dot(Vector3 lhs, Vector3 rhs)
 {
   float result = lhs | rhs;
   return result;
 }
 
+/// Multiplies two vectors per component returning a new vector containing
+/// (lhs.X * rhs.X, lhs.Y * rhs.Y, lhs.Z * rhs.Z)
+/// Input vectors will not be modified
 Vector3 Mul(Vector3 lhs, Vector3 rhs)
 {
   return lhs * rhs;
 }
 
+/// Calculates the cross Product (lhs x rhs) and returns the result
+/// Input vectors will not be modified
 Vector3 Cross(Vector3 lhs, Vector3 rhs)
 {
   return lhs ^ rhs;
 }
 
+/// Calculates the squared length  of the given vector, which is the same as the dot product with the same vector
+/// Input vector will not be modified
 float LengthSquared(Vector3 vec)
 {
   return vec | vec;
 }
 
+/// Calculates the squared length of the X and Y components, ignoring the Z component
+/// Input vector will not be modified
 float LengthSquared2D(Vector3 vec)
 {
   return vec.X * vec.X + vec.Y * vec.Y;
 }
 
+/// Calculates the 2D length of the Vector using the square root of the LengthSquared2D
+/// Input vector will not be modified
 float Length2D(Vector3 vec)
 {
   return Sqrt(vec.LengthSquared2D());
 }
 
+/// Calculates the 2D length of the Vector using the square root of the LengthSquared
+/// Input vector will not be modified
 float Length(Vector3 vec)
 {
   return Sqrt(vec.LengthSquared());
 }
 
+/// Creates a copy of the vector, which is normalized in its length (has a length of 1.0)
 Vector3 NormalizedCopy(Vector3 vec)
 {
   Vector3 copy = vec;
@@ -50,26 +66,39 @@ Vector3 NormalizedCopy(Vector3 vec)
   return copy;
 }
 
+/// Projects a given vector onto a normal (normal needs to be normalized)
+/// Returns the projected vector, which will be a scaled version of the vector
+/// Input vectors will not be modified
 Vector3 ProjectOntoNormal(Vector3 vec, Vector3 normal)
 {
   return normal * (vec | normal);
 }
 
+/// Projects a given vector on a plane, which has the given normal (normal needs to be normalized)
+/// Returns vector which resides on the plane spanned by the normal
+/// Input vector will not be modified
 Vector3 ProjectOntoPlane(Vector3 vec, Vector3 normal)
 {
   return vec - vec.ProjectOntoNormal(normal);
 }
 
+/// Reflects a vector around a normal (normal needs to be normalized)
+/// Returns the reflected vector
+/// Input vectors will not be modified
 Vector3 ReflectVector(Vector3 vec, Vector3 normal)
 {
   return vec - (2 * (vec | normal) * normal);
 }
 
+/// Checks if any component inside the vector is NaN.
+/// Input vector will not be modified
 bool ContainsNaN(Vector3 vec)
 {
   return IsNaN(vec.X) || IsNaN(vec.Y) || IsNaN(vec.Z);
 }
 
+/// Checks if two vectors are nearly equal (are equal with respect to a scaled epsilon)
+/// Input vectors will not be modified
 bool NearlyEquals(Vector3 a, Vector3 b, float epsilon = 1e-4f)
 {
   return krepel.math.NearlyEquals(a.X, b.X, epsilon) &&
@@ -77,12 +106,18 @@ bool NearlyEquals(Vector3 a, Vector3 b, float epsilon = 1e-4f)
          krepel.math.NearlyEquals(a.Z, b.Z, epsilon);
 }
 
+/// Returns a clamped copy of the given vector
+/// The retuned vector will be of size <= MaxSize
+/// Input vector will not be modified
 Vector3 ClampSize(Vector3 vec, float MaxSize)
 {
   Vector3 normal = vec.NormalizedCopy();
   return normal * Min(vec.Length(), MaxSize);
 }
 
+/// Returns a clamped copy of the X and Y component of the Vector, the Z compnent will be untouched
+/// The length of the X and Y component will be <= MaxSize
+/// Input vector will not be modified
 Vector3 ClampSize2D(Vector3 vec, float MaxSize)
 {
   Vector3 clamped = vec;
@@ -119,10 +154,11 @@ struct Vector3
     this.Z = Z;
   }
 
-  // Don't return result to avoid confusion with NormalizedCopy
-  // and stress that this operation modifies the vector on which it is called
+  /// Normalizes the vector (vector will have a length of 1.0)
   void Normalize()
   {
+    // Don't return result to avoid confusion with NormalizedCopy
+    // and stress that this operation modifies the vector on which it is called
     float length = this.Length();
     this /= length;
   }

--- a/code/krepel/math/vector3.d
+++ b/code/krepel/math/vector3.d
@@ -218,10 +218,21 @@ struct Vector3
 
   Vector3 opDispatch(string s)() inout
   {
-    return mixin(
-      "Vector3(" ~ (s[0] == 'O' ? '0' : s[0] ) ~","~
-      (s[1] == 'O' ? '0' : s[1] ) ~","~
-      (s[2] == 'O' ? '0' : s[2] ) ~")");
+    // Special case for setting X to 0 (_0YZ)
+    static if(s.length == 4 && s[0] == '_')
+    {
+      return mixin(
+        "Vector3(" ~ s[1] ~","~
+        s[2] ~","~
+        s[3] ~")");
+    }
+    else if(s.length == 3)
+    {
+      return mixin(
+        "Vector3(" ~ s[0] ~","~
+        s[1] ~","~
+        s[2] ~")");
+    }
   }
 
   __gshared immutable ForwardVector   = Vector3(1,0,0);
@@ -425,7 +436,7 @@ struct Vector3
   {
     Vector3 vec = Vector3(1,2,3);
 
-    Vector3 swizzled = vec.ZOY;
+    Vector3 swizzled = vec.Z0Y;
 
     assert(swizzled == Vector3(3,0,2));
   }

--- a/code/krepel/math/vector3.d
+++ b/code/krepel/math/vector3.d
@@ -304,7 +304,7 @@ struct Vector3
   }
 
   Vector3 opDispatch(string SwizzleString)() inout
-    if(SwizzleString.length == 3 || (SwizzleString.length == 4 && SwizzleString[0] == '_'))
+    if((SwizzleString.length == 3 && SwizzleString[0] != '_') || (SwizzleString.length == 4 && SwizzleString[0] == '_'))
   {
     // Special case for setting X to 0 (_0YZ)
     static if(SwizzleString.length == 4 && SwizzleString[0] == '_' && IsValidSwizzleString(SwizzleString[1..4]))
@@ -324,7 +324,7 @@ struct Vector3
   }
 
   Vector4 opDispatch(string SwizzleString)() inout
-    if(SwizzleString.length == 4 || (SwizzleString.length == 5 && SwizzleString[0] == '_'))
+    if((SwizzleString.length == 4 && SwizzleString[0] != '_') || (SwizzleString.length == 5 && SwizzleString[0] == '_'))
   {
     // Special case for setting X to 0 (_0YZ)
     static if(SwizzleString.length == 5 && SwizzleString[0] == '_' && IsValidSwizzleString(SwizzleString[1..5]))
@@ -560,6 +560,8 @@ struct Vector3
     assert(Vector3(1, 2, 3).ZX   == Vector2(3, 1));
     assert(Vector3(1, 2, 3).XZX  == Vector3(1, 3, 1));
     assert(Vector3(1, 2, 3).XYXY == Vector4(1, 2, 1, 2));
+    assert(Vector3(1, 2, 3)._ZYX == Vector3(3, 2, 1));
+    assert(Vector3(1, 2, 3)._0YX == Vector3(0, 2, 1));
 
     static assert(!__traits(compiles, Vector3(1, 2, 3).Foo), "Swizzling is only supposed to work with value members of " ~ Vector3.stringof ~ ".");
     static assert(!__traits(compiles, Vector3(1, 2, 3).XXXXX), "Swizzling output dimension is limited to 4.");

--- a/code/krepel/math/vector3.d
+++ b/code/krepel/math/vector3.d
@@ -157,11 +157,11 @@ struct Vector3
     }
   }
 
-  __gshared immutable ForwardVector = Vector3(1,0,0);
-  __gshared immutable RightVector = Vector3(0,1,0);
-  __gshared immutable UpVector = Vector3(0,0,1);
+  __gshared immutable ForwardVector   = Vector3(1,0,0);
+  __gshared immutable RightVector     = Vector3(0,1,0);
+  __gshared immutable UpVector        = Vector3(0,0,1);
   __gshared immutable UnitScaleVector = Vector3(1,1,1);
-  __gshared immutable ZeroVector = Vector3(0,0,0);
+  __gshared immutable ZeroVector      = Vector3(0,0,0);
 
   // Initialization test
   unittest

--- a/code/krepel/math/vector3.d
+++ b/code/krepel/math/vector3.d
@@ -201,7 +201,7 @@ struct Vector3
     }
     else
     {
-      assert(false, "Operator " ~ op ~ " not implemented.");
+      static assert(false, "Operator " ~ op ~ " not implemented.");
     }
   }
 
@@ -232,7 +232,7 @@ struct Vector3
     }
     else
     {
-      assert(false, "Operator " ~ op ~ " not implemented.");
+      static assert(false, "Operator " ~ op ~ " not implemented.");
     }
   }
 
@@ -248,7 +248,7 @@ struct Vector3
     }
     else
     {
-      assert(false, "Operator " ~ op ~ " not implemented.");
+      static assert(false, "Operator " ~ op ~ " not implemented.");
     }
   }
 
@@ -264,7 +264,7 @@ struct Vector3
     }
     else
     {
-      assert(false, "Operator " ~ op ~ " not implemented.");
+      static assert(false, "Operator " ~ op ~ " not implemented.");
     }
   }
 

--- a/code/krepel/math/vector3.d
+++ b/code/krepel/math/vector3.d
@@ -1,7 +1,11 @@
 module krepel.math.vector3;
 
 import krepel.math.math;
+import krepel.algorithm.comparison;
 import std.conv;
+
+@nogc:
+@safe:
 
 float Dot(Vector3 lhs, Vector3 rhs)
 {
@@ -22,6 +26,16 @@ Vector3 Cross(Vector3 lhs, Vector3 rhs)
 float LengthSquared(Vector3 vec)
 {
   return vec | vec;
+}
+
+float LengthSquared2D(Vector3 vec)
+{
+  return vec.X * vec.X + vec.Y * vec.Y;
+}
+
+float Length2D(Vector3 vec)
+{
+  return Sqrt(vec.LengthSquared2D());
 }
 
 float Length(Vector3 vec)
@@ -63,8 +77,26 @@ bool NearlyEquals(Vector3 a, Vector3 b, float epsilon = 1e-4f)
          krepel.math.NearlyEquals(a.Z, b.Z, epsilon);
 }
 
+Vector3 ClampSize(Vector3 vec, float MaxSize)
+{
+  Vector3 normal = vec.NormalizedCopy();
+  return normal * Min(vec.Length(), MaxSize);
+}
+
+Vector3 ClampSize2D(Vector3 vec, float MaxSize)
+{
+  Vector3 clamped = vec;
+  clamped.Z = 0;
+  clamped.Normalize();
+  clamped *= Min(vec.Length2D(), MaxSize);
+  clamped.Z = vec.Z;
+  return clamped;
+}
+
 struct Vector3
 {
+  @safe:
+  @nogc:
   union
   {
     struct
@@ -353,5 +385,31 @@ struct Vector3
     Vector3 c = Vector3(1,1,10);
     assert(NearlyEquals(a,b));
     assert(!NearlyEquals(a,c));
+  }
+
+  /// Clamp Vector3
+  unittest
+  {
+    Vector3 vec = Vector3(100,0,0);
+    Vector3 clamped = vec.ClampSize(1);
+    assert(vec == Vector3(100,0,0));
+    assert(clamped == Vector3(1,0,0));
+  }
+
+  /// Clamp2D Vector3
+  unittest
+  {
+    Vector3 vec = Vector3(100,0,1000);
+    Vector3 clamped = vec.ClampSize2D(1);
+    assert(vec == Vector3(100,0,1000));
+    assert(clamped == Vector3(1,0,1000));
+  }
+
+  /// 2D Length
+  unittest
+  {
+    Vector3 vec = Vector3(0,1,1032094);
+    assert(vec.Length2D() == 1);
+    assert(vec.LengthSquared2D() == 1);
   }
 }

--- a/code/krepel/math/vector3.d
+++ b/code/krepel/math/vector3.d
@@ -84,7 +84,7 @@ struct Vector3
     }
   }
 
-  Vector3 opBinary(string op)(Vector3 rhs)
+  Vector3 opBinary(string op)(Vector3 rhs) inout
   {
     // Addition, subtraction, component wise multiplication
     static if(op == "+" || op == "-" || op == "*")
@@ -109,7 +109,7 @@ struct Vector3
     }
   }
 
-  Vector3 opBinary(string op)(float rhs)
+  Vector3 opBinary(string op)(float rhs) inout
   {
     // Vector scaling
     static if(op == "/" || op == "*")
@@ -125,7 +125,7 @@ struct Vector3
     }
   }
 
-  Vector3 opBinaryRight(string op)(float rhs)
+  Vector3 opBinaryRight(string op)(float rhs) inout
   {
     // Vector scaling
     static if(op == "*")
@@ -141,9 +141,11 @@ struct Vector3
     }
   }
 
-  static Vector3 Forward = Vector3(1,0,0);
-  static Vector3 Right = Vector3(0,1,0);
-  static Vector3 Up = Vector3(0,0,1);
+  __gshared immutable ForwardVector = Vector3(1,0,0);
+  __gshared immutable RightVector = Vector3(0,1,0);
+  __gshared immutable UpVector = Vector3(0,0,1);
+  __gshared immutable UnitScaleVector = Vector3(1,1,1);
+  __gshared immutable ZeroVector = Vector3(0,0,0);
 
   // Initialization test
   unittest
@@ -240,14 +242,14 @@ struct Vector3
   unittest
   {
     // Operator
-    auto vec = Vector3.Up ^ Vector3.Forward;
-    assert(vec == Vector3.Right);
+    auto vec = Vector3.UpVector ^ Vector3.ForwardVector;
+    assert(vec == Vector3.RightVector);
     // Function
-    assert(Cross(Vector3.Up, Vector3.Forward) == Vector3.Right);
-    Vector3 vec1 = Vector3.Up;
-    Vector3 vec2 = Vector3.Forward;
+    assert(Cross(Vector3.UpVector, Vector3.ForwardVector) == Vector3.RightVector);
+    Vector3 vec1 = Vector3.UpVector;
+    Vector3 vec2 = Vector3.ForwardVector;
     // UFCS
     Vector3 vec3 = vec1.Cross(vec2);
-    assert(vec3 == Vector3.Right);
+    assert(vec3 == Vector3.RightVector);
   }
 }

--- a/code/krepel/math/vector3.d
+++ b/code/krepel/math/vector3.d
@@ -46,6 +46,10 @@ Vector3 ProjectOntoPlane(Vector3 vec, Vector3 normal)
   return vec - vec.ProjectOntoNormal(normal);
 }
 
+Vector3 ReflectVector(Vector3 vec, Vector3 normal)
+{
+  return vec - (2 * (vec | normal) * normal);
+}
 
 struct Vector3
 {
@@ -315,5 +319,16 @@ struct Vector3
     Vector3 projected = toProject.ProjectOntoPlane(normal);
 
     assert(projected == Vector3(1,1,0));
+  }
+
+  /// Reflect Vector
+  unittest
+  {
+    Vector3 normal = Vector3(1,0,0);
+    Vector3 reflection = Vector3(-1,0,-1);
+
+    Vector3 reflected = reflection.ReflectVector(normal);
+
+    assert(reflected == Vector3(1,0,-1));
   }
 }

--- a/code/krepel/math/vector3.d
+++ b/code/krepel/math/vector3.d
@@ -56,6 +56,13 @@ bool ContainsNaN(Vector3 vec)
   return IsNaN(vec.X) || IsNaN(vec.Y) || IsNaN(vec.Z);
 }
 
+bool NearlyEquals(Vector3 a, Vector3 b, float epsilon = 1e-4f)
+{
+  return krepel.math.NearlyEquals(a.X, b.X, epsilon) &&
+         krepel.math.NearlyEquals(a.Y, b.Y, epsilon) &&
+         krepel.math.NearlyEquals(a.Z, b.Z, epsilon);
+}
+
 struct Vector3
 {
   union
@@ -336,5 +343,15 @@ struct Vector3
     Vector3 reflected = reflection.ReflectVector(normal);
 
     assert(reflected == Vector3(1,0,-1));
+  }
+
+  /// NearlyEquals
+  unittest
+  {
+    Vector3 a = Vector3(1,1,0);
+    Vector3 b = Vector3(1+1e-5f,1,-1e-6f);
+    Vector3 c = Vector3(1,1,10);
+    assert(NearlyEquals(a,b));
+    assert(!NearlyEquals(a,c));
   }
 }

--- a/code/krepel/math/vector3.d
+++ b/code/krepel/math/vector3.d
@@ -10,125 +10,125 @@ import std.conv;
 @safe:
 nothrow:
 
-/// Calculates the Dot Product of the two vectors
-/// Input vectors will not be modified
-float Dot(Vector3 lhs, Vector3 rhs)
+/// Calculates the Dot Product of the two Vectors
+/// Input Vectors will not be modified
+float Dot(Vector3 Lhs, Vector3 Rhs)
 {
-  float result = lhs | rhs;
-  return result;
+  float Result = Lhs | Rhs;
+  return Result;
 }
 
-/// Multiplies two vectors per component returning a new vector containing
-/// (lhs.X * rhs.X, lhs.Y * rhs.Y, lhs.Z * rhs.Z)
-/// Input vectors will not be modified
-Vector3 Mul(Vector3 lhs, Vector3 rhs)
+/// Multiplies two Vectors per component returning a new Vector containing
+/// (Lhs.X * Rhs.X, Lhs.Y * Rhs.Y, Lhs.Z * Rhs.Z)
+/// Input Vectors will not be modified
+Vector3 Mul(Vector3 Lhs, Vector3 Rhs)
 {
-  return lhs * rhs;
+  return Lhs * Rhs;
 }
 
-/// Calculates the cross Product (lhs x rhs) and returns the result
-/// Input vectors will not be modified
-Vector3 Cross(Vector3 lhs, Vector3 rhs)
+/// Calculates the cross Product (Lhs x Rhs) and returns the result
+/// Input Vectors will not be modified
+Vector3 Cross(Vector3 Lhs, Vector3 Rhs)
 {
-  return lhs ^ rhs;
+  return Lhs ^ Rhs;
 }
 
-/// Calculates the squared length  of the given vector, which is the same as the dot product with the same vector
-/// Input vector will not be modified
-float LengthSquared(Vector3 vec)
+/// Calculates the squared length  of the given Vector, which is the same as the dot product with the same Vector
+/// Input Vector will not be modified
+float LengthSquared(Vector3 Vec)
 {
-  return vec | vec;
+  return Vec | Vec;
 }
 
 /// Calculates the squared length of the X and Y components, ignoring the Z component
-/// Input vector will not be modified
-float LengthSquared2D(Vector3 vec)
+/// Input Vector will not be modified
+float LengthSquared2D(Vector3 Vec)
 {
-  return vec.X * vec.X + vec.Y * vec.Y;
+  return Vec.X * Vec.X + Vec.Y * Vec.Y;
 }
 
 /// Calculates the 2D length of the Vector using the square root of the LengthSquared2D
-/// Input vector will not be modified
-float Length2D(Vector3 vec)
+/// Input Vector will not be modified
+float Length2D(Vector3 Vec)
 {
-  return Sqrt(vec.LengthSquared2D());
+  return Sqrt(Vec.LengthSquared2D());
 }
 
 /// Calculates the 2D length of the Vector using the square root of the LengthSquared
-/// Input vector will not be modified
-float Length(Vector3 vec)
+/// Input Vector will not be modified
+float Length(Vector3 Vec)
 {
-  return Sqrt(vec.LengthSquared());
+  return Sqrt(Vec.LengthSquared());
 }
 
-/// Creates a copy of the vector, which is normalized in its length (has a length of 1.0)
-Vector3 NormalizedCopy(Vector3 vec)
+/// Creates a copy of the Vector, which is Normalized in its length (has a length of 1.0)
+Vector3 NormalizedCopy(Vector3 Vec)
 {
-  Vector3 copy = vec;
-  copy.Normalize();
-  return copy;
+  Vector3 Copy = Vec;
+  Copy.Normalize();
+  return Copy;
 }
 
-/// Projects a given vector onto a normal (normal needs to be normalized)
-/// Returns the projected vector, which will be a scaled version of the vector
-/// Input vectors will not be modified
-Vector3 ProjectOntoNormal(Vector3 vec, Vector3 normal)
+/// Projects a given Vector onto a Normal (Normal needs to be Normalized)
+/// Returns the projected Vector, which will be a scaled version of the Vector
+/// Input Vectors will not be modified
+Vector3 ProjectOntoNormal(Vector3 Vec, Vector3 Normal)
 {
-  return normal * (vec | normal);
+  return Normal * (Vec | Normal);
 }
 
-/// Projects a given vector on a plane, which has the given normal (normal needs to be normalized)
-/// Returns vector which resides on the plane spanned by the normal
-/// Input vector will not be modified
-Vector3 ProjectOntoPlane(Vector3 vec, Vector3 normal)
+/// Projects a given Vector on a plane, which has the given Normal (Normal needs to be Normalized)
+/// Returns Vector which resides on the plane spanned by the Normal
+/// Input Vector will not be modified
+Vector3 ProjectOntoPlane(Vector3 Vec, Vector3 Normal)
 {
-  return vec - vec.ProjectOntoNormal(normal);
+  return Vec - Vec.ProjectOntoNormal(Normal);
 }
 
-/// Reflects a vector around a normal (normal needs to be normalized)
-/// Returns the reflected vector
-/// Input vectors will not be modified
-Vector3 ReflectVector(Vector3 vec, Vector3 normal)
+/// Reflects a Vector around a Normal (Normal needs to be Normalized)
+/// Returns the reflected Vector
+/// Input Vectors will not be modified
+Vector3 ReflectVector(Vector3 Vec, Vector3 Normal)
 {
-  return vec - (2 * (vec | normal) * normal);
+  return Vec - (2 * (Vec | Normal) * Normal);
 }
 
-/// Checks if any component inside the vector is NaN.
-/// Input vector will not be modified
-bool ContainsNaN(Vector3 vec)
+/// Checks if any component inside the Vector is NaN.
+/// Input Vector will not be modified
+bool ContainsNaN(Vector3 Vec)
 {
-  return IsNaN(vec.X) || IsNaN(vec.Y) || IsNaN(vec.Z);
+  return IsNaN(Vec.X) || IsNaN(Vec.Y) || IsNaN(Vec.Z);
 }
 
-/// Checks if two vectors are nearly equal (are equal with respect to a scaled epsilon)
-/// Input vectors will not be modified
-bool NearlyEquals(Vector3 a, Vector3 b, float epsilon = 1e-4f)
+/// Checks if two Vectors are nearly equal (are equal with respect to a scaled epsilon)
+/// Input Vectors will not be modified
+bool NearlyEquals(Vector3 A, Vector3 B, float Epsilon = 1e-4f)
 {
-  return krepel.math.NearlyEquals(a.X, b.X, epsilon) &&
-         krepel.math.NearlyEquals(a.Y, b.Y, epsilon) &&
-         krepel.math.NearlyEquals(a.Z, b.Z, epsilon);
+  return krepel.math.NearlyEquals(A.X, B.X, Epsilon) &&
+         krepel.math.NearlyEquals(A.Y, B.Y, Epsilon) &&
+         krepel.math.NearlyEquals(A.Z, B.Z, Epsilon);
 }
 
-/// Returns a clamped copy of the given vector
-/// The retuned vector will be of size <= MaxSize
-/// Input vector will not be modified
-Vector3 ClampSize(Vector3 vec, float MaxSize)
+/// Returns a clamped copy of the given Vector
+/// The retuned Vector will be of size <= MaxSize
+/// Input Vector will not be modified
+Vector3 ClampSize(Vector3 Vec, float MaxSize)
 {
-  Vector3 normal = vec.NormalizedCopy();
-  return normal * Min(vec.Length(), MaxSize);
+  Vector3 Normal = Vec.NormalizedCopy();
+  return Normal * Min(Vec.Length(), MaxSize);
 }
 
 /// Returns a clamped copy of the X and Y component of the Vector, the Z compnent will be untouched
 /// The length of the X and Y component will be <= MaxSize
-/// Input vector will not be modified
-Vector3 ClampSize2D(Vector3 vec, float MaxSize)
+/// Input Vector will not be modified
+Vector3 ClampSize2D(Vector3 Vec, float MaxSize)
 {
-  Vector3 clamped = vec;
-  clamped.Z = 0;
-  clamped.Normalize();
-  clamped *= Min(vec.Length2D(), MaxSize);
-  clamped.Z = vec.Z;
-  return clamped;
+  Vector3 Clamped = Vec;
+  Clamped.Z = 0;
+  Clamped.Normalize();
+  Clamped *= Min(Vec.Length2D(), MaxSize);
+  Clamped.Z = Vec.Z;
+  return Clamped;
 }
 
 struct Vector3
@@ -158,50 +158,50 @@ struct Vector3
     this.Z = Z;
   }
 
-  this(Vector2 vec, float Z)
+  this(Vector2 Vec, float Z)
   {
-    this.Data[0..2] = vec.Data[];
+    this.Data[0..2] = Vec.Data[];
     this.Z = Z;
   }
 
-  this(float X, Vector2 vec)
+  this(float X, Vector2 Vec)
   {
     this.X = X;
-    this.Data[1..3] = vec.Data[];
+    this.Data[1..3] = Vec.Data[];
   }
 
-  /// Normalizes the vector (vector will have a length of 1.0)
+  /// Normalizes the Vector (Vector will have a length of 1.0)
   void Normalize()
   {
     // Don't return result to avoid confusion with NormalizedCopy
-    // and stress that this operation modifies the vector on which it is called
-    float length = this.Length();
-    this /= length;
+    // and stress that this operation modifies the Vector on which it is called
+    float Length = this.Length();
+    this /= Length;
   }
 
   // Dot product
-  float opBinary(string op:"|")(Vector3 rhs)
+  float opBinary(string Op:"|")(Vector3 Rhs)
   {
     return
-      X * rhs.X +
-      Y * rhs.Y +
-      Z * rhs.Z;
+      X * Rhs.X +
+      Y * Rhs.Y +
+      Z * Rhs.Z;
   }
 
-  Vector3 opOpAssign(string op)(float rhs)
+  Vector3 opOpAssign(string Operator)(float Rhs)
   {
-    static if(op == "*" || op == "/")
+    static if(Operator == "*" || Operator == "/")
     {
-      auto result = mixin("Vector3("~
-        "X" ~ op ~ "rhs,"
-        "Y" ~ op ~ "rhs,"
-        "Z" ~ op ~ "rhs)");
-      Data = result.Data;
+      auto Result = mixin("Vector3("~
+        "X" ~ Operator ~ "Rhs,"
+        "Y" ~ Operator ~ "Rhs,"
+        "Z" ~ Operator ~ "Rhs)");
+      Data = Result.Data;
       return this;
     }
     else
     {
-      static assert(false, "Operator " ~ op ~ " not implemented.");
+      static assert(false, "Operator " ~ Operator ~ " not implemented.");
     }
   }
 
@@ -211,60 +211,60 @@ struct Vector3
   //  return "{X:"~text(X)~", Y:"~text(Y)~", Z:"~text(Z)~"}";
   //}
 
-  Vector3 opBinary(string op)(Vector3 rhs) inout
+  Vector3 opBinary(string Operator)(Vector3 Rhs) const
   {
     // Addition, subtraction, component wise multiplication
-    static if(op == "+" || op == "-" || op == "*")
+    static if(Operator == "+" || Operator == "-" || Operator == "*")
     {
       return mixin("Vector3("~
-        "X" ~ op ~ "rhs.X,"
-        "Y" ~ op ~ "rhs.Y,"
-        "Z" ~ op ~ "rhs.Z)");
+        "X" ~ Operator ~ "Rhs.X,"
+        "Y" ~ Operator ~ "Rhs.Y,"
+        "Z" ~ Operator ~ "Rhs.Z)");
     }
     // Cross Product
-    else if(op == "^")
+    else static if(Operator == "^")
     {
       return Vector3(
-        (Y * rhs.Z) - (Z * rhs.Y),
-        (Z * rhs.X) - (X * rhs.Z),
-        (X * rhs.Y) - (Y * rhs.X)
+        (Y * Rhs.Z) - (Z * Rhs.Y),
+        (Z * Rhs.X) - (X * Rhs.Z),
+        (X * Rhs.Y) - (Y * Rhs.X)
       );
     }
     else
     {
-      static assert(false, "Operator " ~ op ~ " not implemented.");
+      static assert(false, "Operator " ~ Operator ~ " not implemented.");
     }
   }
 
-  Vector3 opBinary(string op)(float rhs) inout
+  Vector3 opBinary(string Operator)(float Rhs) const
   {
     // Vector scaling
-    static if(op == "/" || op == "*")
+    static if(Operator == "/" || Operator == "*")
     {
       return mixin("Vector3("~
-        "X" ~ op ~ "rhs,"
-        "Y" ~ op ~ "rhs,"
-        "Z" ~ op ~ "rhs)");
+        "X" ~ Operator ~ "Rhs,"
+        "Y" ~ Operator ~ "Rhs,"
+        "Z" ~ Operator ~ "Rhs)");
     }
     else
     {
-      static assert(false, "Operator " ~ op ~ " not implemented.");
+      static assert(false, "Operator " ~ Operator ~ " not implemented.");
     }
   }
 
-  Vector3 opBinaryRight(string op)(float rhs) inout
+  Vector3 opBinaryRight(string Operator)(float Rhs) inout
   {
     // Vector scaling
-    static if(op == "*")
+    static if(Operator == "*")
     {
       return mixin("Vector3("~
-        "X" ~ op ~ "rhs,"
-        "Y" ~ op ~ "rhs,"
-        "Z" ~ op ~ "rhs)");
+        "X" ~ Operator ~ "Rhs,"
+        "Y" ~ Operator ~ "Rhs,"
+        "Z" ~ Operator ~ "Rhs)");
     }
     else
     {
-      static assert(false, "Operator " ~ op ~ " not implemented.");
+      static assert(false, "Operator " ~ Operator ~ " not implemented.");
     }
   }
 
@@ -354,192 +354,192 @@ struct Vector3
   // Initialization test
   unittest
   {
-    Vector3 v3 = Vector3(1,2,3);
-    assert(v3.X == 1);
-    assert(v3.Y == 2);
-    assert(v3.Z == 3);
-    assert(v3.Data[0] == 1);
-    assert(v3.Data[1] == 2);
-    assert(v3.Data[2] == 3);
+    Vector3 V3 = Vector3(1,2,3);
+    assert(V3.X == 1);
+    assert(V3.Y == 2);
+    assert(V3.Z == 3);
+    assert(V3.Data[0] == 1);
+    assert(V3.Data[1] == 2);
+    assert(V3.Data[2] == 3);
 
-    v3 = Vector3(5);
-    assert(v3.X == 5);
-    assert(v3.Y == 5);
-    assert(v3.Z == 5);
+    V3 = Vector3(5);
+    assert(V3.X == 5);
+    assert(V3.Y == 5);
+    assert(V3.Z == 5);
   }
 
   // Addition test
   unittest
   {
-    Vector3 v1 = Vector3(1,2,3);
-    Vector3 v2 = Vector3(10,11,12);
-    auto v3 = v1 + v2;
-    assert(v3.X == 11);
-    assert(v3.Y == 13);
-    assert(v3.Z == 15);
+    Vector3 V1 = Vector3(1,2,3);
+    Vector3 V2 = Vector3(10,11,12);
+    auto V3 = V1 + V2;
+    assert(V3.X == 11);
+    assert(V3.Y == 13);
+    assert(V3.Z == 15);
   }
 
   // Subtraction test
   unittest
   {
-    Vector3 v1 = Vector3(1,2,3);
-    Vector3 v2 = Vector3(10,11,12);
-    auto v3 = v1 - v2;
-    assert(v3.X == -9);
-    assert(v3.Y == -9);
-    assert(v3.Z == -9);
+    Vector3 V1 = Vector3(1,2,3);
+    Vector3 V2 = Vector3(10,11,12);
+    auto V3 = V1 - V2;
+    assert(V3.X == -9);
+    assert(V3.Y == -9);
+    assert(V3.Z == -9);
   }
 
   // Float multiplication test
   unittest
   {
-    Vector3 v1 = Vector3(1,2,3) * 5;
-    Vector3 v2 = Vector3(1,2,3) * 5.0f;
-    assert(v1 == Vector3(5,10,15));
-    assert(v2 == Vector3(5,10,15));
+    Vector3 V1 = Vector3(1,2,3) * 5;
+    Vector3 V2 = Vector3(1,2,3) * 5.0f;
+    assert(V1 == Vector3(5,10,15));
+    assert(V2 == Vector3(5,10,15));
 
-    v1 = 5 * Vector3(1,2,3);
-    v2 = 5.0f * Vector3(1,2,3);
-    assert(v1 == Vector3(5,10,15));
-    assert(v2 == Vector3(5,10,15));
+    V1 = 5 * Vector3(1,2,3);
+    V2 = 5.0f * Vector3(1,2,3);
+    assert(V1 == Vector3(5,10,15));
+    assert(V2 == Vector3(5,10,15));
   }
 
   // Float division test
   unittest
   {
-    Vector3 v1 = Vector3(5,10,15) / 5;
-    Vector3 v2 = Vector3(5,10,15) / 5.0f;
-    assert(v1 == Vector3(1,2,3));
-    assert(v2 == Vector3(1,2,3));
+    Vector3 V1 = Vector3(5,10,15) / 5;
+    Vector3 V2 = Vector3(5,10,15) / 5.0f;
+    assert(V1 == Vector3(1,2,3));
+    assert(V2 == Vector3(1,2,3));
 
-    v1 = Vector3(5,10,15);
-    v2 = Vector3(5,10,15);
-    v1 /= 5;
-    v2 /= 5.0f;
-    assert(v1 == Vector3(1,2,3));
-    assert(v2 == Vector3(1,2,3));
+    V1 = Vector3(5,10,15);
+    V2 = Vector3(5,10,15);
+    V1 /= 5;
+    V2 /= 5.0f;
+    assert(V1 == Vector3(1,2,3));
+    assert(V2 == Vector3(1,2,3));
   }
 
   /// Dot product test
   unittest
   {
-    Vector3 v1 = Vector3(1,2,3);
-    Vector3 v2 = Vector3(10,11,12);
-    auto v3 = v1 | v2;
-    assert(v3 == 10 + 22 + 36);
-    assert(v3 == v1.Dot(v2));
+    Vector3 V1 = Vector3(1,2,3);
+    Vector3 V2 = Vector3(10,11,12);
+    auto V3 = V1 | V2;
+    assert(V3 == 10 + 22 + 36);
+    assert(V3 == V1.Dot(V2));
   }
 
   /// Component wise multiplication test
   unittest
   {
-    Vector3 v1 = Vector3(1,2,3);
-    Vector3 v2 = Vector3(10,11,12);
-    auto v3 = v1 * v2;
-    assert(v3.X == 10);
-    assert(v3.Y == 22);
-    assert(v3.Z == 36);
-    assert(v3 == v1.Mul(v2));
+    Vector3 V1 = Vector3(1,2,3);
+    Vector3 V2 = Vector3(10,11,12);
+    auto V3 = V1 * V2;
+    assert(V3.X == 10);
+    assert(V3.Y == 22);
+    assert(V3.Z == 36);
+    assert(V3 == V1.Mul(V2));
   }
 
   /// Cross Product
   unittest
   {
     // Operator
-    auto vec = Vector3.UpVector ^ Vector3.ForwardVector;
-    assert(vec == Vector3.RightVector);
+    auto Vec = Vector3.UpVector ^ Vector3.ForwardVector;
+    assert(Vec == Vector3.RightVector);
     // Function
     assert(Cross(Vector3.UpVector, Vector3.ForwardVector) == Vector3.RightVector);
-    Vector3 vec1 = Vector3.UpVector;
-    Vector3 vec2 = Vector3.ForwardVector;
+    Vector3 Vec1 = Vector3.UpVector;
+    Vector3 Vec2 = Vector3.ForwardVector;
     // UFCS
-    Vector3 vec3 = vec1.Cross(vec2);
-    assert(vec3 == Vector3.RightVector);
+    Vector3 Vec3 = Vec1.Cross(Vec2);
+    assert(Vec3 == Vector3.RightVector);
   }
 
   /// Normalization
   unittest
   {
-    Vector3 vec = Vector3(1,1,1);
-    vec.Normalize();
-    float expected = 1.0f/Sqrt(3);
-    assert(vec == Vector3(expected, expected, expected));
+    Vector3 Vec = Vector3(1,1,1);
+    Vec.Normalize();
+    float Expected = 1.0f/Sqrt(3);
+    assert(Vec == Vector3(Expected, Expected, Expected));
 
-    vec = Vector3(1,1,1);
-    auto normalized = vec.NormalizedCopy();
-    auto normalizedUFCS = NormalizedCopy(vec);
-    assert(vec == Vector3(1,1,1));
-    assert(normalized == Vector3(expected, expected, expected));
-    assert(normalizedUFCS == Vector3(expected, expected, expected));
+    Vec = Vector3(1,1,1);
+    auto Normalized = Vec.NormalizedCopy();
+    auto NormalizedUFCS = NormalizedCopy(Vec);
+    assert(Vec == Vector3(1,1,1));
+    assert(Normalized == Vector3(Expected, Expected, Expected));
+    assert(NormalizedUFCS == Vector3(Expected, Expected, Expected));
   }
 
   /// Project Onto Normal
   unittest
   {
-    Vector3 normal = Vector3.UpVector;
-    Vector3 toProject = Vector3(1,1,0.5f);
+    Vector3 Normal = Vector3.UpVector;
+    Vector3 ToProject = Vector3(1,1,0.5f);
 
-    Vector3 projected = toProject.ProjectOntoNormal(normal);
+    Vector3 Projected = ToProject.ProjectOntoNormal(Normal);
 
-    assert(projected == Vector3(0,0,0.5f));
+    assert(Projected == Vector3(0,0,0.5f));
   }
 
   /// Project Onto PLane
   unittest
   {
-    Vector3 normal = Vector3.UpVector;
-    Vector3 toProject = Vector3(1,1,0.5f);
+    Vector3 Normal = Vector3.UpVector;
+    Vector3 ToProject = Vector3(1,1,0.5f);
 
-    Vector3 projected = toProject.ProjectOntoPlane(normal);
+    Vector3 Projected = ToProject.ProjectOntoPlane(Normal);
 
-    assert(projected == Vector3(1,1,0));
+    assert(Projected == Vector3(1,1,0));
   }
 
   /// Reflect Vector
   unittest
   {
-    Vector3 normal = Vector3(1,0,0);
-    Vector3 reflection = Vector3(-1,0,-1);
+    Vector3 Normal = Vector3(1,0,0);
+    Vector3 Reflection = Vector3(-1,0,-1);
 
-    Vector3 reflected = reflection.ReflectVector(normal);
+    Vector3 Reflected = Reflection.ReflectVector(Normal);
 
-    assert(reflected == Vector3(1,0,-1));
+    assert(Reflected == Vector3(1,0,-1));
   }
 
   /// NearlyEquals
   unittest
   {
-    Vector3 a = Vector3(1,1,0);
-    Vector3 b = Vector3(1+1e-5f,1,-1e-6f);
-    Vector3 c = Vector3(1,1,10);
-    assert(NearlyEquals(a,b));
-    assert(!NearlyEquals(a,c));
+    Vector3 A = Vector3(1,1,0);
+    Vector3 B = Vector3(1+1e-5f,1,-1e-6f);
+    Vector3 C = Vector3(1,1,10);
+    assert(NearlyEquals(A,B));
+    assert(!NearlyEquals(A,C));
   }
 
   /// Clamp Vector3
   unittest
   {
-    Vector3 vec = Vector3(100,0,0);
-    Vector3 clamped = vec.ClampSize(1);
-    assert(vec == Vector3(100,0,0));
-    assert(clamped == Vector3(1,0,0));
+    Vector3 Vec = Vector3(100,0,0);
+    Vector3 Clamped = Vec.ClampSize(1);
+    assert(Vec == Vector3(100,0,0));
+    assert(Clamped == Vector3(1,0,0));
   }
 
   /// Clamp2D Vector3
   unittest
   {
-    Vector3 vec = Vector3(100,0,1000);
-    Vector3 clamped = vec.ClampSize2D(1);
-    assert(vec == Vector3(100,0,1000));
-    assert(clamped == Vector3(1,0,1000));
+    Vector3 Vec = Vector3(100,0,1000);
+    Vector3 Clamped = Vec.ClampSize2D(1);
+    assert(Vec == Vector3(100,0,1000));
+    assert(Clamped == Vector3(1,0,1000));
   }
 
   /// 2D Length
   unittest
   {
-    Vector3 vec = Vector3(0,1,1032094);
-    assert(vec.Length2D() == 1);
-    assert(vec.LengthSquared2D() == 1);
+    Vector3 Vec = Vector3(0,1,1032094);
+    assert(Vec.Length2D() == 1);
+    assert(Vec.LengthSquared2D() == 1);
   }
 
   // Vector3

--- a/code/krepel/math/vector4.d
+++ b/code/krepel/math/vector4.d
@@ -1,0 +1,474 @@
+module krepel.math.vector4;
+
+import krepel.math.math;
+import krepel.algorithm.comparison;
+import krepel.math.vector3;
+import std.conv;
+
+@nogc:
+@safe:
+
+/// Calculates the Dot Product of the two vectors
+/// Input vectors will not be modified
+float Dot(Vector4 lhs, Vector4 rhs)
+{
+  float result = lhs | rhs;
+  return result;
+}
+
+/// Multiplies two vectors per component returning a new vector containing
+/// (lhs.X * rhs.X, lhs.Y * rhs.Y, lhs.Z * rhs.Z)
+/// Input vectors will not be modified
+Vector4 Mul(Vector4 lhs, Vector4 rhs)
+{
+  return lhs * rhs;
+}
+
+/// Calculates the squared length  of the given vector, which is the same as the dot product with the same vector
+/// Input vector will not be modified
+float LengthSquared(Vector4 vec)
+{
+  return vec | vec;
+}
+
+/// Calculates the squared length of the X and Y components, ignoring the Z component
+/// Input vector will not be modified
+float LengthSquared2D(Vector4 vec)
+{
+  return vec.X * vec.X + vec.Y * vec.Y;
+}
+
+/// Calculates the 2D length of the Vector using the square root of the LengthSquared2D
+/// Input vector will not be modified
+float Length2D(Vector4 vec)
+{
+  return Sqrt(vec.LengthSquared2D());
+}
+
+/// Calculates the 2D length of the Vector using the square root of the LengthSquared
+/// Input vector will not be modified
+float Length(Vector4 vec)
+{
+  return Sqrt(vec.LengthSquared());
+}
+
+/// Creates a copy of the vector, which is normalized in its length (has a length of 1.0)
+Vector4 NormalizedCopy(Vector4 vec)
+{
+  Vector4 copy = vec;
+  copy.Normalize();
+  return copy;
+}
+
+/// Projects a given vector onto a normal (normal needs to be normalized)
+/// Returns the projected vector, which will be a scaled version of the vector
+/// Input vectors will not be modified
+Vector4 ProjectOntoNormal(Vector4 vec, Vector4 normal)
+{
+  return normal * (vec | normal);
+}
+
+/// Projects a given vector on a plane, which has the given normal (normal needs to be normalized)
+/// Returns vector which resides on the plane spanned by the normal
+/// Input vector will not be modified
+Vector4 ProjectOntoPlane(Vector4 vec, Vector4 normal)
+{
+  return vec - vec.ProjectOntoNormal(normal);
+}
+
+/// Reflects a vector around a normal (normal needs to be normalized)
+/// Returns the reflected vector
+/// Input vectors will not be modified
+Vector4 ReflectVector(Vector4 vec, Vector4 normal)
+{
+  return vec - (2 * (vec | normal) * normal);
+}
+
+/// Checks if any component inside the vector is NaN.
+/// Input vector will not be modified
+bool ContainsNaN(Vector4 vec)
+{
+  return IsNaN(vec.X) || IsNaN(vec.Y) || IsNaN(vec.Z);
+}
+
+/// Checks if two vectors are nearly equal (are equal with respect to a scaled epsilon)
+/// Input vectors will not be modified
+bool NearlyEquals(Vector4 a, Vector4 b, float epsilon = 1e-4f)
+{
+  return krepel.math.NearlyEquals(a.X, b.X, epsilon) &&
+         krepel.math.NearlyEquals(a.Y, b.Y, epsilon) &&
+         krepel.math.NearlyEquals(a.Z, b.Z, epsilon) &&
+         krepel.math.NearlyEquals(a.W, b.W, epsilon);
+}
+
+/// Returns a clamped copy of the given vector
+/// The retuned vector will be of size <= MaxSize
+/// Input vector will not be modified
+Vector4 ClampSize(Vector4 vec, float MaxSize)
+{
+  Vector4 normal = vec.NormalizedCopy();
+  return normal * Min(vec.Length(), MaxSize);
+}
+
+/// Returns a clamped copy of the X and Y component of the Vector, the Z compnent will be untouched
+/// The length of the X and Y component will be <= MaxSize
+/// Input vector will not be modified
+Vector4 ClampSize2D(Vector4 vec, float MaxSize)
+{
+  Vector4 clamped = vec;
+  clamped.Z = 0;
+  clamped.W = 0;
+  clamped.Normalize();
+  clamped *= Min(vec.Length2D(), MaxSize);
+  clamped.Z = vec.Z;
+  clamped.W = vec.W;
+  return clamped;
+}
+
+struct Vector4
+{
+  @safe:
+  @nogc:
+  union
+  {
+    struct
+    {
+      float X, Y, Z, W;
+    }
+    float[4] Data;
+  }
+  this(float Value)
+  {
+    X = Value;
+    Y = Value;
+    Z = Value;
+    W = Value;
+  }
+
+  this(Vector3 vec, float W)
+  {
+    this.Data[0..3] = vec.Data[];
+    this.W = W;
+  }
+
+  this(float X, float Y, float Z, float W)
+  {
+    this.X = X;
+    this.Y = Y;
+    this.Z = Z;
+    this.W = W;
+  }
+
+  /// Normalizes the vector (vector will have a length of 1.0)
+  void Normalize()
+  {
+    // Don't return result to avoid confusion with NormalizedCopy
+    // and stress that this operation modifies the vector on which it is called
+    float length = this.Length();
+    this /= length;
+  }
+
+  // Dot product
+  float opBinary(string op:"|")(Vector4 rhs)
+  {
+    return
+      X * rhs.X +
+      Y * rhs.Y +
+      Z * rhs.Z +
+      W * rhs.W;
+  }
+
+  Vector4 opOpAssign(string op)(float rhs)
+  {
+    static if(op == "*" || op == "/")
+    {
+      auto result = mixin("Vector4("~
+        "X" ~ op ~ "rhs,"
+        "Y" ~ op ~ "rhs,"
+        "Z" ~ op ~ "rhs,"
+        "W" ~ op ~ "rhs)");
+      Data = result.Data;
+      return this;
+    }
+    else
+    {
+      assert(false, "Operator " ~ op ~ " not implemented.");
+    }
+  }
+
+  //const (char)[] ToString() const
+  //{
+  //  // TODO: More memory friendly (no GC) implementation?
+  //  return "{X:"~text(X)~", Y:"~text(Y)~", Z:"~text(Z)~"}";
+  //}
+
+  Vector4 opBinary(string op)(Vector4 rhs) inout
+  {
+    // Addition, subtraction, component wise multiplication
+    static if(op == "+" || op == "-" || op == "*")
+    {
+      return mixin("Vector4("~
+        "X" ~ op ~ "rhs.X,"
+        "Y" ~ op ~ "rhs.Y,"
+        "Z" ~ op ~ "rhs.Z,"
+        "W" ~ op ~ "rhs.W)");
+    }
+    else
+    {
+      assert(false, "Operator " ~ op ~ " not implemented.");
+    }
+  }
+
+  Vector4 opBinary(string op)(float rhs) inout
+  {
+    // Vector scaling
+    static if(op == "/" || op == "*")
+    {
+      return mixin("Vector4("~
+        "X" ~ op ~ "rhs,"
+        "Y" ~ op ~ "rhs,"
+        "Z" ~ op ~ "rhs,"
+        "W" ~ op ~ "rhs)");
+    }
+    else
+    {
+      assert(false, "Operator " ~ op ~ " not implemented.");
+    }
+  }
+
+  Vector4 opBinaryRight(string op)(float rhs) inout
+  {
+    // Vector scaling
+    static if(op == "*")
+    {
+      return mixin("Vector4("~
+        "X" ~ op ~ "rhs,"
+        "Y" ~ op ~ "rhs,"
+        "Z" ~ op ~ "rhs,"
+        "W" ~ op ~ "rhs)");
+    }
+    else
+    {
+      assert(false, "Operator " ~ op ~ " not implemented.");
+    }
+  }
+
+  Vector4 opDispatch(string s)() const
+  {
+    // Special case for setting X to 0 (_0YZ)
+    static if(s.length == 5 && s[0] == '_')
+    {
+      return mixin(
+        "Vector4(" ~ s[1] ~","~
+        s[2] ~","~
+        s[3] ~","~
+        s[4] ~")");
+    }
+    else static if(s.length == 4 && s[0] != '_')
+    {
+      return mixin(
+        "Vector4(" ~ s[0] ~","~
+        s[1] ~","~
+        s[2] ~","~
+        s[3] ~")");
+    }
+  }
+
+  __gshared immutable ForwardVector   = Vector4(1,0,0,0);
+  __gshared immutable RightVector     = Vector4(0,1,0,0);
+  __gshared immutable UpVector        = Vector4(0,0,1,0);
+  __gshared immutable WeightVector    = Vector4(0,0,0,1);
+  __gshared immutable UnitScaleVector = Vector4(1,1,1,1);
+  __gshared immutable ZeroVector      = Vector4(0,0,0,0);
+
+  // Initialization test
+  unittest
+  {
+    Vector4 v3 = Vector4(1,2,3,4);
+    assert(v3.X == 1);
+    assert(v3.Y == 2);
+    assert(v3.Z == 3);
+    assert(v3.W == 4);
+    assert(v3.Data[0] == 1);
+    assert(v3.Data[1] == 2);
+    assert(v3.Data[2] == 3);
+    assert(v3.Data[3] == 4);
+
+    v3 = Vector4(5);
+    assert(v3.X == 5);
+    assert(v3.Y == 5);
+    assert(v3.Z == 5);
+    assert(v3.W == 5);
+  }
+
+  // Addition test
+  unittest
+  {
+    Vector4 v1 = Vector4(1,2,3,4);
+    Vector4 v2 = Vector4(10,11,12,13);
+    auto v3 = v1 + v2;
+    assert(v3.X == 11);
+    assert(v3.Y == 13);
+    assert(v3.Z == 15);
+    assert(v3.W == 17);
+  }
+
+  // Subtraction test
+  unittest
+  {
+    Vector4 v1 = Vector4(1,2,3,4);
+    Vector4 v2 = Vector4(10,11,12,13);
+    auto v3 = v1 - v2;
+    assert(v3.X == -9);
+    assert(v3.Y == -9);
+    assert(v3.Z == -9);
+    assert(v3.W == -9);
+  }
+
+  // Float multiplication test
+  unittest
+  {
+    Vector4 v1 = Vector4(1,2,3,4) * 5;
+    Vector4 v2 = Vector4(1,2,3,4) * 5.0f;
+    assert(v1 == Vector4(5,10,15,20));
+    assert(v2 == Vector4(5,10,15,20));
+
+    v1 = 5 * Vector4(1,2,3,4);
+    v2 = 5.0f * Vector4(1,2,3,4);
+    assert(v1 == Vector4(5,10,15,20));
+    assert(v2 == Vector4(5,10,15,20));
+  }
+
+  // Float division test
+  unittest
+  {
+    Vector4 v1 = Vector4(5,10,15,20) / 5;
+    Vector4 v2 = Vector4(5,10,15,20) / 5.0f;
+    assert(v1 == Vector4(1,2,3,4));
+    assert(v2 == Vector4(1,2,3,4));
+
+    v1 = Vector4(5,10,15,20);
+    v2 = Vector4(5,10,15,20);
+    v1 /= 5;
+    v2 /= 5.0f;
+    assert(v1 == Vector4(1,2,3,4));
+    assert(v2 == Vector4(1,2,3,4));
+  }
+
+  /// Dot product test
+  unittest
+  {
+    Vector4 v1 = Vector4(1,2,3,4);
+    Vector4 v2 = Vector4(10,11,12,13);
+    auto v3 = v1 | v2;
+    assert(v3 == 10 + 22 + 36 + 52);
+    assert(v3 == v1.Dot(v2));
+  }
+
+  /// Component wise multiplication test
+  unittest
+  {
+    Vector4 v1 = Vector4(1,2,3,4);
+    Vector4 v2 = Vector4(10,11,12,13);
+    auto v3 = v1 * v2;
+    assert(v3.X == 10);
+    assert(v3.Y == 22);
+    assert(v3.Z == 36);
+    assert(v3.W == 52);
+    assert(v3 == v1.Mul(v2));
+  }
+
+  /// Normalization
+  unittest
+  {
+    Vector4 vec = Vector4(1,1,1,1);
+    vec.Normalize();
+    float expected = 1.0f/Sqrt(4);
+    assert(vec == Vector4(expected, expected, expected, expected));
+
+    vec = Vector4(1,1,1,1);
+    auto normalized = vec.NormalizedCopy();
+    auto normalizedUFCS = NormalizedCopy(vec);
+    assert(vec == Vector4(1,1,1,1));
+    assert(normalized == Vector4(expected, expected, expected, expected));
+    assert(normalizedUFCS == Vector4(expected, expected, expected, expected));
+  }
+
+  /// Project Onto Normal
+  unittest
+  {
+    Vector4 normal = Vector4.UpVector;
+    Vector4 toProject = Vector4(1,1,0.5f,0);
+
+    Vector4 projected = toProject.ProjectOntoNormal(normal);
+
+    assert(projected == Vector4(0,0,0.5f,0));
+  }
+
+  /// Project Onto PLane
+  unittest
+  {
+    Vector4 normal = Vector4.UpVector;
+    Vector4 toProject = Vector4(1,1,0.5f,0);
+
+    Vector4 projected = toProject.ProjectOntoPlane(normal);
+
+    assert(projected == Vector4(1,1,0,0));
+  }
+
+  /// Reflect Vector
+  unittest
+  {
+    Vector4 normal = Vector4(1,0,0,0);
+    Vector4 reflection = Vector4(-1,0,-1,0);
+
+    Vector4 reflected = reflection.ReflectVector(normal);
+
+    assert(reflected == Vector4(1,0,-1,0));
+  }
+
+  /// NearlyEquals
+  unittest
+  {
+    Vector4 a = Vector4(1,1,0,1);
+    Vector4 b = Vector4(1+1e-5f,1,-1e-6f,1);
+    Vector4 c = Vector4(1,1,1,10);
+    assert(NearlyEquals(a,b));
+    assert(!NearlyEquals(a,c));
+  }
+
+  /// Clamp Vector4
+  unittest
+  {
+    Vector4 vec = Vector4(0,0,0,100);
+    Vector4 clamped = vec.ClampSize(1);
+    assert(vec == Vector4(0,0,0,100));
+    assert(clamped == Vector4(0,0,0,1));
+  }
+
+  /// Clamp2D Vector4
+  unittest
+  {
+    Vector4 vec = Vector4(100,0,1000,2000);
+    Vector4 clamped = vec.ClampSize2D(1);
+    assert(vec == Vector4(100,0,1000,2000));
+    assert(clamped == Vector4(1,0,1000,2000));
+  }
+
+  /// 2D Length
+  unittest
+  {
+    Vector4 vec = Vector4(0,1,1032094,34857);
+    assert(vec.Length2D() == 1);
+    assert(vec.LengthSquared2D() == 1);
+  }
+
+  unittest
+  {
+    Vector4 vec = Vector4(1,2,3,4);
+
+    Vector4 swizzled = vec.Z0YW;
+
+    assert(swizzled == Vector4(3,0,2,4));
+  }
+}

--- a/code/krepel/math/vector4.d
+++ b/code/krepel/math/vector4.d
@@ -326,7 +326,7 @@ struct Vector4
   }
 
   Vector3 opDispatch(string SwizzleString)() inout
-    if(SwizzleString.length == 3 || (SwizzleString.length == 4 && SwizzleString[0] == '_'))
+    if((SwizzleString.length == 3 && SwizzleString[0] != '_') || (SwizzleString.length == 4 && SwizzleString[0] == '_'))
   {
     // Special case for setting X to 0 (_0YZ)
     static if(SwizzleString.length == 4 && SwizzleString[0] == '_' && IsValidSwizzleString(SwizzleString[1..4]))
@@ -346,7 +346,7 @@ struct Vector4
   }
 
   Vector4 opDispatch(string SwizzleString)() inout
-    if(SwizzleString.length == 4 || (SwizzleString.length == 5 && SwizzleString[0] == '_'))
+    if((SwizzleString.length == 4 && SwizzleString[0] != '_') || (SwizzleString.length == 5 && SwizzleString[0] == '_'))
   {
     // Special case for setting X to 0 (_0YZ)
     static if(SwizzleString.length == 5 && SwizzleString[0] == '_' && IsValidSwizzleString(SwizzleString[1..5]))

--- a/code/krepel/math/vector4.d
+++ b/code/krepel/math/vector4.d
@@ -10,121 +10,121 @@ import std.conv;
 @safe:
 nothrow:
 
-/// Calculates the Dot Product of the two vectors
-/// Input vectors will not be modified
-float Dot(Vector4 lhs, Vector4 rhs)
+/// Calculates the Dot Product of the two Vectors
+/// Input Vectors will not be modified
+float Dot(Vector4 Lhs, Vector4 Rhs)
 {
-  float result = lhs | rhs;
-  return result;
+  float Result = Lhs | Rhs;
+  return Result;
 }
 
-/// Multiplies two vectors per component returning a new vector containing
-/// (lhs.X * rhs.X, lhs.Y * rhs.Y, lhs.Z * rhs.Z)
-/// Input vectors will not be modified
-Vector4 Mul(Vector4 lhs, Vector4 rhs)
+/// Multiplies two Vectors per component returning a new Vector containing
+/// (Lhs.X * Rhs.X, Lhs.Y * Rhs.Y, Lhs.Z * Rhs.Z)
+/// Input Vectors will not be modified
+Vector4 Mul(Vector4 Lhs, Vector4 Rhs)
 {
-  return lhs * rhs;
+  return Lhs * Rhs;
 }
 
-/// Calculates the squared length  of the given vector, which is the same as the dot product with the same vector
-/// Input vector will not be modified
-float LengthSquared(Vector4 vec)
+/// Calculates the squared length  of the given Vector, which is the same as the dot product with the same Vector
+/// Input Vector will not be modified
+float LengthSquared(Vector4 Vec)
 {
-  return vec | vec;
+  return Vec | Vec;
 }
 
 /// Calculates the squared length of the X and Y components, ignoring the Z component
-/// Input vector will not be modified
-float LengthSquared2D(Vector4 vec)
+/// Input Vector will not be modified
+float LengthSquared2D(Vector4 Vec)
 {
-  return vec.X * vec.X + vec.Y * vec.Y;
+  return Vec.X * Vec.X + Vec.Y * Vec.Y;
 }
 
 /// Calculates the 2D length of the Vector using the square root of the LengthSquared2D
-/// Input vector will not be modified
-float Length2D(Vector4 vec)
+/// Input Vector will not be modified
+float Length2D(Vector4 Vec)
 {
-  return Sqrt(vec.LengthSquared2D());
+  return Sqrt(Vec.LengthSquared2D());
 }
 
 /// Calculates the 2D length of the Vector using the square root of the LengthSquared
-/// Input vector will not be modified
-float Length(Vector4 vec)
+/// Input Vector will not be modified
+float Length(Vector4 Vec)
 {
-  return Sqrt(vec.LengthSquared());
+  return Sqrt(Vec.LengthSquared());
 }
 
-/// Creates a copy of the vector, which is normalized in its length (has a length of 1.0)
-Vector4 NormalizedCopy(Vector4 vec)
+/// Creates a copy of the Vector, which is Normalized in its length (has a length of 1.0)
+Vector4 NormalizedCopy(Vector4 Vec)
 {
-  Vector4 copy = vec;
+  Vector4 copy = Vec;
   copy.Normalize();
   return copy;
 }
 
-/// Projects a given vector onto a normal (normal needs to be normalized)
-/// Returns the projected vector, which will be a scaled version of the vector
-/// Input vectors will not be modified
-Vector4 ProjectOntoNormal(Vector4 vec, Vector4 normal)
+/// Projects a given Vector onto a Normal (Normal needs to be Normalized)
+/// Returns the Projected Vector, which will be a scaled version of the Vector
+/// Input Vectors will not be modified
+Vector4 ProjectOntoNormal(Vector4 Vec, Vector4 Normal)
 {
-  return normal * (vec | normal);
+  return Normal * (Vec | Normal);
 }
 
-/// Projects a given vector on a plane, which has the given normal (normal needs to be normalized)
-/// Returns vector which resides on the plane spanned by the normal
-/// Input vector will not be modified
-Vector4 ProjectOntoPlane(Vector4 vec, Vector4 normal)
+/// Projects a given Vector on a plane, which has the given Normal (Normal needs to be Normalized)
+/// Returns Vector which resides on the plane spanned by the Normal
+/// Input Vector will not be modified
+Vector4 ProjectOntoPlane(Vector4 Vec, Vector4 Normal)
 {
-  return vec - vec.ProjectOntoNormal(normal);
+  return Vec - Vec.ProjectOntoNormal(Normal);
 }
 
-/// Reflects a vector around a normal (normal needs to be normalized)
-/// Returns the reflected vector
-/// Input vectors will not be modified
-Vector4 ReflectVector(Vector4 vec, Vector4 normal)
+/// Reflects a Vector around a Normal (Normal needs to be Normalized)
+/// Returns the reflected Vector
+/// Input Vectors will not be modified
+Vector4 ReflectVector(Vector4 Vec, Vector4 Normal)
 {
-  return vec - (2 * (vec | normal) * normal);
+  return Vec - (2 * (Vec | Normal) * Normal);
 }
 
-/// Checks if any component inside the vector is NaN.
-/// Input vector will not be modified
-bool ContainsNaN(Vector4 vec)
+/// Checks if any component inside the Vector is NaN.
+/// Input Vector will not be modified
+bool ContainsNaN(Vector4 Vec)
 {
-  return IsNaN(vec.X) || IsNaN(vec.Y) || IsNaN(vec.Z);
+  return IsNaN(Vec.X) || IsNaN(Vec.Y) || IsNaN(Vec.Z);
 }
 
-/// Checks if two vectors are nearly equal (are equal with respect to a scaled epsilon)
-/// Input vectors will not be modified
-bool NearlyEquals(Vector4 a, Vector4 b, float epsilon = 1e-4f)
+/// Checks if two Vectors are nearly equal (are equal with respect to a scaled epsilon)
+/// Input Vectors will not be modified
+bool NearlyEquals(Vector4 A, Vector4 B, float Epsilon = 1e-4f)
 {
-  return krepel.math.NearlyEquals(a.X, b.X, epsilon) &&
-         krepel.math.NearlyEquals(a.Y, b.Y, epsilon) &&
-         krepel.math.NearlyEquals(a.Z, b.Z, epsilon) &&
-         krepel.math.NearlyEquals(a.W, b.W, epsilon);
+  return krepel.math.NearlyEquals(A.X, B.X, Epsilon) &&
+         krepel.math.NearlyEquals(A.Y, B.Y, Epsilon) &&
+         krepel.math.NearlyEquals(A.Z, B.Z, Epsilon) &&
+         krepel.math.NearlyEquals(A.W, B.W, Epsilon);
 }
 
-/// Returns a clamped copy of the given vector
-/// The retuned vector will be of size <= MaxSize
-/// Input vector will not be modified
-Vector4 ClampSize(Vector4 vec, float MaxSize)
+/// Returns a Clamped copy of the given Vector
+/// The retuned Vector will be of size <= MaxSize
+/// Input Vector will not be modified
+Vector4 ClampSize(Vector4 Vec, float MaxSize)
 {
-  Vector4 normal = vec.NormalizedCopy();
-  return normal * Min(vec.Length(), MaxSize);
+  Vector4 Normal = Vec.NormalizedCopy();
+  return Normal * Min(Vec.Length(), MaxSize);
 }
 
-/// Returns a clamped copy of the X and Y component of the Vector, the Z compnent will be untouched
+/// Returns a Clamped copy of the X and Y component of the Vector, the Z compnent will be untouched
 /// The length of the X and Y component will be <= MaxSize
-/// Input vector will not be modified
-Vector4 ClampSize2D(Vector4 vec, float MaxSize)
+/// Input Vector will not be modified
+Vector4 ClampSize2D(Vector4 Vec, float MaxSize)
 {
-  Vector4 clamped = vec;
-  clamped.Z = 0;
-  clamped.W = 0;
-  clamped.Normalize();
-  clamped *= Min(vec.Length2D(), MaxSize);
-  clamped.Z = vec.Z;
-  clamped.W = vec.W;
-  return clamped;
+  Vector4 Clamped = Vec;
+  Clamped.Z = 0;
+  Clamped.W = 0;
+  Clamped.Normalize();
+  Clamped *= Min(Vec.Length2D(), MaxSize);
+  Clamped.Z = Vec.Z;
+  Clamped.W = Vec.W;
+  return Clamped;
 }
 
 struct Vector4
@@ -149,42 +149,42 @@ struct Vector4
     W = Value;
   }
 
-  this(Vector2 vec, float Z, float W)
+  this(Vector2 Vec, float Z, float W)
   {
-    this.Data[0..2] = vec.Data[];
+    this.Data[0..2] = Vec.Data[];
     this.Z = Z;
     this.W = W;
   }
 
-  this(float X, Vector2 vec, float W)
+  this(float X, Vector2 Vec, float W)
   {
-    this.Data[1..3] = vec.Data[];
+    this.Data[1..3] = Vec.Data[];
     this.X = X;
     this.W = W;
   }
 
-  this(float X, float Y, Vector2 vec)
+  this(float X, float Y, Vector2 Vec)
   {
-    this.Data[2..4] = vec.Data[];
+    this.Data[2..4] = Vec.Data[];
     this.X = X;
     this.Y = Y;
   }
 
-  this(Vector2 vec1, Vector2 vec2)
+  this(Vector2 Vec1, Vector2 Vec2)
   {
-    this.Data[0..2] = vec1.Data[];
-    this.Data[2..4] = vec2.Data[];
+    this.Data[0..2] = Vec1.Data[];
+    this.Data[2..4] = Vec2.Data[];
   }
 
-  this(Vector3 vec, float W)
+  this(Vector3 Vec, float W)
   {
-    this.Data[0..3] = vec.Data[];
+    this.Data[0..3] = Vec.Data[];
     this.W = W;
   }
 
-  this(float X, Vector3 vec)
+  this(float X, Vector3 Vec)
   {
-    this.Data[1..4] = vec.Data[];
+    this.Data[1..4] = Vec.Data[];
     this.X = X;
   }
 
@@ -196,40 +196,40 @@ struct Vector4
     this.W = W;
   }
 
-  /// Normalizes the vector (vector will have a length of 1.0)
+  /// Normalizes the Vector (Vector will have a length of 1.0)
   void Normalize()
   {
-    // Don't return result to avoid confusion with NormalizedCopy
-    // and stress that this operation modifies the vector on which it is called
-    float length = this.Length();
-    this /= length;
+    // Don't return Result to avoid confusion with NormalizedCopy
+    // and stress that this operation modifies the Vector on which it is called
+    float Length = this.Length();
+    this /= Length;
   }
 
   // Dot product
-  float opBinary(string op:"|")(Vector4 rhs)
+  float opBinary(string Operator:"|")(Vector4 Rhs)
   {
     return
-      X * rhs.X +
-      Y * rhs.Y +
-      Z * rhs.Z +
-      W * rhs.W;
+      X * Rhs.X +
+      Y * Rhs.Y +
+      Z * Rhs.Z +
+      W * Rhs.W;
   }
 
-  Vector4 opOpAssign(string op)(float rhs)
+  Vector4 opOpAssign(string Operator)(float Rhs)
   {
-    static if(op == "*" || op == "/")
+    static if(Operator == "*" || Operator == "/")
     {
-      auto result = mixin("Vector4("~
-        "X" ~ op ~ "rhs,"
-        "Y" ~ op ~ "rhs,"
-        "Z" ~ op ~ "rhs,"
-        "W" ~ op ~ "rhs)");
-      Data = result.Data;
+      auto Result = mixin("Vector4("~
+        "X" ~ Operator ~ "Rhs,"
+        "Y" ~ Operator ~ "Rhs,"
+        "Z" ~ Operator ~ "Rhs,"
+        "W" ~ Operator ~ "Rhs)");
+      Data = Result.Data;
       return this;
     }
     else
     {
-      static assert(false, "Operator " ~ op ~ " not implemented.");
+      static assert(false, "Operator " ~ Operator ~ " not implemented.");
     }
   }
 
@@ -239,54 +239,54 @@ struct Vector4
   //  return "{X:"~text(X)~", Y:"~text(Y)~", Z:"~text(Z)~"}";
   //}
 
-  Vector4 opBinary(string op)(Vector4 rhs) inout
+  Vector4 opBinary(string Operator)(Vector4 Rhs) inout
   {
     // Addition, subtraction, component wise multiplication
-    static if(op == "+" || op == "-" || op == "*")
+    static if(Operator == "+" || Operator == "-" || Operator == "*")
     {
       return mixin("Vector4("~
-        "X" ~ op ~ "rhs.X,"
-        "Y" ~ op ~ "rhs.Y,"
-        "Z" ~ op ~ "rhs.Z,"
-        "W" ~ op ~ "rhs.W)");
+        "X" ~ Operator ~ "Rhs.X,"
+        "Y" ~ Operator ~ "Rhs.Y,"
+        "Z" ~ Operator ~ "Rhs.Z,"
+        "W" ~ Operator ~ "Rhs.W)");
     }
     else
     {
-      static assert(false, "Operator " ~ op ~ " not implemented.");
+      static assert(false, "Operator " ~ Operator ~ " not implemented.");
     }
   }
 
-  Vector4 opBinary(string op)(float rhs) inout
+  Vector4 opBinary(string Operator)(float Rhs) inout
   {
     // Vector scaling
-    static if(op == "/" || op == "*")
+    static if(Operator == "/" || Operator == "*")
     {
       return mixin("Vector4("~
-        "X" ~ op ~ "rhs,"
-        "Y" ~ op ~ "rhs,"
-        "Z" ~ op ~ "rhs,"
-        "W" ~ op ~ "rhs)");
+        "X" ~ Operator ~ "Rhs,"
+        "Y" ~ Operator ~ "Rhs,"
+        "Z" ~ Operator ~ "Rhs,"
+        "W" ~ Operator ~ "Rhs)");
     }
     else
     {
-      static assert(false, "Operator " ~ op ~ " not implemented.");
+      static assert(false, "Operator " ~ Operator ~ " not implemented.");
     }
   }
 
-  Vector4 opBinaryRight(string op)(float rhs) inout
+  Vector4 opBinaryRight(string Operator)(float Rhs) inout
   {
     // Vector scaling
-    static if(op == "*")
+    static if(Operator == "*")
     {
       return mixin("Vector4("~
-        "X" ~ op ~ "rhs,"
-        "Y" ~ op ~ "rhs,"
-        "Z" ~ op ~ "rhs,"
-        "W" ~ op ~ "rhs)");
+        "X" ~ Operator ~ "Rhs,"
+        "Y" ~ Operator ~ "Rhs,"
+        "Z" ~ Operator ~ "Rhs,"
+        "W" ~ Operator ~ "Rhs)");
     }
     else
     {
-      static assert(false, "Operator " ~ op ~ " not implemented.");
+      static assert(false, "Operator " ~ Operator ~ " not implemented.");
     }
   }
 
@@ -307,64 +307,63 @@ struct Vector4
     return true;
   }
 
-  Vector4 opDispatch(string s)() const
-    if(s.length==4 || (s.length == 5 && s[0] == '_'))
+  Vector2 opDispatch(string SwizzleString)() inout
+    if(SwizzleString.length == 2 || (SwizzleString.length == 3 && SwizzleString[0] == '_'))
   {
     // Special case for setting X to 0 (_0YZ)
-    static if(s.length == 5 && s[0] == '_' &&
-      IsValidSwizzleString(s[1..5]))
+    static if(SwizzleString.length == 3 && SwizzleString[0] == '_' && IsValidSwizzleString(SwizzleString[1..3]))
     {
-      mixin(
-        "return typeof(return)(" ~ s[1] ~","~
-        s[2] ~","~
-        s[3] ~","~
-        s[4] ~");");
+      return mixin(
+        "typeof(return)(" ~ SwizzleString[1] ~","~
+        SwizzleString[2] ~")");
     }
-    else static if(s.length == 4 && s[0] != '_' && IsValidSwizzleString(s))
+    else static if(SwizzleString.length == 2 && IsValidSwizzleString(SwizzleString))
     {
-      mixin(
-        "return typeof(return)(" ~ s[0] ~","~
-        s[1] ~","~
-        s[2] ~","~
-        s[3] ~");");
+      return mixin(
+        "typeof(return)(" ~ SwizzleString[0] ~","~
+        SwizzleString[1] ~")");
     }
   }
 
-  Vector3 opDispatch(string s)() const
-    if(s.length==3 || (s.length == 4 && s[0] == '_'))
+  Vector3 opDispatch(string SwizzleString)() inout
+    if(SwizzleString.length == 3 || (SwizzleString.length == 4 && SwizzleString[0] == '_'))
   {
     // Special case for setting X to 0 (_0YZ)
-    static if(s.length == 4 && s[0] == '_' && IsValidSwizzleString(s[1..4]))
+    static if(SwizzleString.length == 4 && SwizzleString[0] == '_' && IsValidSwizzleString(SwizzleString[1..4]))
     {
-      mixin(
-        "return typeof(return)(" ~ s[1] ~","~
-        s[2] ~","~
-        s[3] ~");");
+      return mixin(
+        "typeof(return)(" ~ SwizzleString[1] ~","~
+        SwizzleString[2] ~","~
+        SwizzleString[3] ~")");
     }
-    else static if(s.length == 3 && IsValidSwizzleString(s))
+    else static if(SwizzleString.length == 3 && IsValidSwizzleString(SwizzleString))
     {
-      mixin(
-        "return typeof(return)(" ~ s[0] ~","~
-        s[1] ~","~
-        s[2] ~");");
+      return mixin(
+        "typeof(return)(" ~ SwizzleString[0] ~","~
+        SwizzleString[1] ~","~
+        SwizzleString[2] ~")");
     }
   }
 
-  Vector2 opDispatch(string s)() const
-    if(s.length==2 || (s.length == 3 && s[0] == '_'))
+  Vector4 opDispatch(string SwizzleString)() inout
+    if(SwizzleString.length == 4 || (SwizzleString.length == 5 && SwizzleString[0] == '_'))
   {
     // Special case for setting X to 0 (_0YZ)
-    static if(s.length == 3 && s[0] == '_' && IsValidSwizzleString(s[1..2]))
+    static if(SwizzleString.length == 5 && SwizzleString[0] == '_' && IsValidSwizzleString(SwizzleString[1..5]))
     {
-      mixin(
-        "return typeof(return)(" ~ s[1] ~","~
-        s[2] ~");");
+      return mixin(
+        "typeof(return)(" ~ SwizzleString[1] ~","~
+        SwizzleString[2] ~","~
+        SwizzleString[3] ~","~
+        SwizzleString[4] ~")");
     }
-    else static if(s.length == 2 && IsValidSwizzleString(s))
+    else static if(SwizzleString.length == 4 && IsValidSwizzleString(SwizzleString))
     {
-      mixin(
-        "return typeof(return)(" ~ s[0] ~","~
-        s[1] ~");");
+      return mixin(
+        "typeof(return)(" ~ SwizzleString[0] ~","~
+        SwizzleString[1] ~","~
+        SwizzleString[2] ~","~
+        SwizzleString[3] ~")");
     }
   }
 
@@ -378,210 +377,210 @@ struct Vector4
   // Initialization test
   unittest
   {
-    Vector4 v3 = Vector4(1,2,3,4);
-    assert(v3.X == 1);
-    assert(v3.Y == 2);
-    assert(v3.Z == 3);
-    assert(v3.W == 4);
-    assert(v3.Data[0] == 1);
-    assert(v3.Data[1] == 2);
-    assert(v3.Data[2] == 3);
-    assert(v3.Data[3] == 4);
+    Vector4 V3 = Vector4(1,2,3,4);
+    assert(V3.X == 1);
+    assert(V3.Y == 2);
+    assert(V3.Z == 3);
+    assert(V3.W == 4);
+    assert(V3.Data[0] == 1);
+    assert(V3.Data[1] == 2);
+    assert(V3.Data[2] == 3);
+    assert(V3.Data[3] == 4);
 
-    v3 = Vector4(5);
-    assert(v3.X == 5);
-    assert(v3.Y == 5);
-    assert(v3.Z == 5);
-    assert(v3.W == 5);
+    V3 = Vector4(5);
+    assert(V3.X == 5);
+    assert(V3.Y == 5);
+    assert(V3.Z == 5);
+    assert(V3.W == 5);
   }
 
   // Addition test
   unittest
   {
-    Vector4 v1 = Vector4(1,2,3,4);
-    Vector4 v2 = Vector4(10,11,12,13);
-    auto v3 = v1 + v2;
-    assert(v3.X == 11);
-    assert(v3.Y == 13);
-    assert(v3.Z == 15);
-    assert(v3.W == 17);
+    Vector4 V1 = Vector4(1,2,3,4);
+    Vector4 V2 = Vector4(10,11,12,13);
+    auto V3 = V1 + V2;
+    assert(V3.X == 11);
+    assert(V3.Y == 13);
+    assert(V3.Z == 15);
+    assert(V3.W == 17);
   }
 
   // Subtraction test
   unittest
   {
-    Vector4 v1 = Vector4(1,2,3,4);
-    Vector4 v2 = Vector4(10,11,12,13);
-    auto v3 = v1 - v2;
-    assert(v3.X == -9);
-    assert(v3.Y == -9);
-    assert(v3.Z == -9);
-    assert(v3.W == -9);
+    Vector4 V1 = Vector4(1,2,3,4);
+    Vector4 V2 = Vector4(10,11,12,13);
+    auto V3 = V1 - V2;
+    assert(V3.X == -9);
+    assert(V3.Y == -9);
+    assert(V3.Z == -9);
+    assert(V3.W == -9);
   }
 
   // Float multiplication test
   unittest
   {
-    Vector4 v1 = Vector4(1,2,3,4) * 5;
-    Vector4 v2 = Vector4(1,2,3,4) * 5.0f;
-    assert(v1 == Vector4(5,10,15,20));
-    assert(v2 == Vector4(5,10,15,20));
+    Vector4 V1 = Vector4(1,2,3,4) * 5;
+    Vector4 V2 = Vector4(1,2,3,4) * 5.0f;
+    assert(V1 == Vector4(5,10,15,20));
+    assert(V2 == Vector4(5,10,15,20));
 
-    v1 = 5 * Vector4(1,2,3,4);
-    v2 = 5.0f * Vector4(1,2,3,4);
-    assert(v1 == Vector4(5,10,15,20));
-    assert(v2 == Vector4(5,10,15,20));
+    V1 = 5 * Vector4(1,2,3,4);
+    V2 = 5.0f * Vector4(1,2,3,4);
+    assert(V1 == Vector4(5,10,15,20));
+    assert(V2 == Vector4(5,10,15,20));
   }
 
   // Float division test
   unittest
   {
-    Vector4 v1 = Vector4(5,10,15,20) / 5;
-    Vector4 v2 = Vector4(5,10,15,20) / 5.0f;
-    assert(v1 == Vector4(1,2,3,4));
-    assert(v2 == Vector4(1,2,3,4));
+    Vector4 V1 = Vector4(5,10,15,20) / 5;
+    Vector4 V2 = Vector4(5,10,15,20) / 5.0f;
+    assert(V1 == Vector4(1,2,3,4));
+    assert(V2 == Vector4(1,2,3,4));
 
-    v1 = Vector4(5,10,15,20);
-    v2 = Vector4(5,10,15,20);
-    v1 /= 5;
-    v2 /= 5.0f;
-    assert(v1 == Vector4(1,2,3,4));
-    assert(v2 == Vector4(1,2,3,4));
+    V1 = Vector4(5,10,15,20);
+    V2 = Vector4(5,10,15,20);
+    V1 /= 5;
+    V2 /= 5.0f;
+    assert(V1 == Vector4(1,2,3,4));
+    assert(V2 == Vector4(1,2,3,4));
   }
 
   /// Dot product test
   unittest
   {
-    Vector4 v1 = Vector4(1,2,3,4);
-    Vector4 v2 = Vector4(10,11,12,13);
-    auto v3 = v1 | v2;
-    assert(v3 == 10 + 22 + 36 + 52);
-    assert(v3 == v1.Dot(v2));
+    Vector4 V1 = Vector4(1,2,3,4);
+    Vector4 V2 = Vector4(10,11,12,13);
+    auto V3 = V1 | V2;
+    assert(V3 == 10 + 22 + 36 + 52);
+    assert(V3 == V1.Dot(V2));
   }
 
   /// Component wise multiplication test
   unittest
   {
-    Vector4 v1 = Vector4(1,2,3,4);
-    Vector4 v2 = Vector4(10,11,12,13);
-    auto v3 = v1 * v2;
-    assert(v3.X == 10);
-    assert(v3.Y == 22);
-    assert(v3.Z == 36);
-    assert(v3.W == 52);
-    assert(v3 == v1.Mul(v2));
+    Vector4 V1 = Vector4(1,2,3,4);
+    Vector4 V2 = Vector4(10,11,12,13);
+    auto V3 = V1 * V2;
+    assert(V3.X == 10);
+    assert(V3.Y == 22);
+    assert(V3.Z == 36);
+    assert(V3.W == 52);
+    assert(V3 == V1.Mul(V2));
   }
 
   /// Normalization
   unittest
   {
-    Vector4 vec = Vector4(1,1,1,1);
-    vec.Normalize();
-    float expected = 1.0f/Sqrt(4);
-    assert(vec == Vector4(expected, expected, expected, expected));
+    Vector4 Vec = Vector4(1,1,1,1);
+    Vec.Normalize();
+    float Expected = 1.0f/Sqrt(4);
+    assert(Vec == Vector4(Expected, Expected, Expected, Expected));
 
-    vec = Vector4(1,1,1,1);
-    auto normalized = vec.NormalizedCopy();
-    auto normalizedUFCS = NormalizedCopy(vec);
-    assert(vec == Vector4(1,1,1,1));
-    assert(normalized == Vector4(expected, expected, expected, expected));
-    assert(normalizedUFCS == Vector4(expected, expected, expected, expected));
+    Vec = Vector4(1,1,1,1);
+    auto Normalized = Vec.NormalizedCopy();
+    auto NormalizedUFCS = NormalizedCopy(Vec);
+    assert(Vec == Vector4(1,1,1,1));
+    assert(Normalized == Vector4(Expected, Expected, Expected, Expected));
+    assert(NormalizedUFCS == Vector4(Expected, Expected, Expected, Expected));
   }
 
   /// Project Onto Normal
   unittest
   {
-    Vector4 normal = Vector4.UpVector;
-    Vector4 toProject = Vector4(1,1,0.5f,0);
+    Vector4 Normal = Vector4.UpVector;
+    Vector4 ToProject = Vector4(1,1,0.5f,0);
 
-    Vector4 projected = toProject.ProjectOntoNormal(normal);
+    Vector4 Projected = ToProject.ProjectOntoNormal(Normal);
 
-    assert(projected == Vector4(0,0,0.5f,0));
+    assert(Projected == Vector4(0,0,0.5f,0));
   }
 
   /// Project Onto PLane
   unittest
   {
-    Vector4 normal = Vector4.UpVector;
-    Vector4 toProject = Vector4(1,1,0.5f,0);
+    Vector4 Normal = Vector4.UpVector;
+    Vector4 ToProject = Vector4(1,1,0.5f,0);
 
-    Vector4 projected = toProject.ProjectOntoPlane(normal);
+    Vector4 Projected = ToProject.ProjectOntoPlane(Normal);
 
-    assert(projected == Vector4(1,1,0,0));
+    assert(Projected == Vector4(1,1,0,0));
   }
 
   /// Reflect Vector
   unittest
   {
-    Vector4 normal = Vector4(1,0,0,0);
-    Vector4 reflection = Vector4(-1,0,-1,0);
+    Vector4 Normal = Vector4(1,0,0,0);
+    Vector4 Reflection = Vector4(-1,0,-1,0);
 
-    Vector4 reflected = reflection.ReflectVector(normal);
+    Vector4 Reflected = Reflection.ReflectVector(Normal);
 
-    assert(reflected == Vector4(1,0,-1,0));
+    assert(Reflected == Vector4(1,0,-1,0));
   }
 
   /// NearlyEquals
   unittest
   {
-    Vector4 a = Vector4(1,1,0,1);
-    Vector4 b = Vector4(1+1e-5f,1,-1e-6f,1);
-    Vector4 c = Vector4(1,1,1,10);
-    assert(NearlyEquals(a,b));
-    assert(!NearlyEquals(a,c));
+    Vector4 A = Vector4(1,1,0,1);
+    Vector4 B = Vector4(1+1e-5f,1,-1e-6f,1);
+    Vector4 C = Vector4(1,1,1,10);
+    assert(NearlyEquals(A,B));
+    assert(!NearlyEquals(A,C));
   }
 
   /// Clamp Vector4
   unittest
   {
-    Vector4 vec = Vector4(0,0,0,100);
-    Vector4 clamped = vec.ClampSize(1);
-    assert(vec == Vector4(0,0,0,100));
-    assert(clamped == Vector4(0,0,0,1));
+    Vector4 Vec = Vector4(0,0,0,100);
+    Vector4 Clamped = Vec.ClampSize(1);
+    assert(Vec == Vector4(0,0,0,100));
+    assert(Clamped == Vector4(0,0,0,1));
   }
 
   /// Clamp2D Vector4
   unittest
   {
-    Vector4 vec = Vector4(100,0,1000,2000);
-    Vector4 clamped = vec.ClampSize2D(1);
-    assert(vec == Vector4(100,0,1000,2000));
-    assert(clamped == Vector4(1,0,1000,2000));
+    Vector4 Vec = Vector4(100,0,1000,2000);
+    Vector4 Clamped = Vec.ClampSize2D(1);
+    assert(Vec == Vector4(100,0,1000,2000));
+    assert(Clamped == Vector4(1,0,1000,2000));
   }
 
   /// 2D Length
   unittest
   {
-    Vector4 vec = Vector4(0,1,1032094,34857);
-    assert(vec.Length2D() == 1);
-    assert(vec.LengthSquared2D() == 1);
+    Vector4 Vec = Vector4(0,1,1032094,34857);
+    assert(Vec.Length2D() == 1);
+    assert(Vec.LengthSquared2D() == 1);
   }
 
   unittest
   {
-    Vector4 vec = Vector4(1,2,3,4);
+    Vector4 Vec = Vector4(1,2,3,4);
 
-    Vector4 swizzled = vec.Z0YW;
+    Vector4 Swizzled = Vec.Z0YW;
 
-    assert(swizzled == Vector4(3,0,2,4));
+    assert(Swizzled == Vector4(3,0,2,4));
   }
 
   unittest
   {
-    Vector4 vec = Vector4(1,2,3,4);
+    Vector4 Vec = Vector4(1,2,3,4);
 
-    Vector3 swizzled = vec.Z0Y;
+    Vector3 Swizzled = Vec.Z0Y;
 
-    assert(swizzled == Vector3(3,0,2));
+    assert(Swizzled == Vector3(3,0,2));
   }
 
   unittest
   {
-    Vector4 vec = Vector4(1,2,3,4);
+    Vector4 Vec = Vector4(1,2,3,4);
 
-    Vector2 swizzled = vec.ZY;
+    Vector2 Swizzled = Vec.ZY;
 
-    assert(swizzled == Vector2(3,2));
+    assert(Swizzled == Vector2(3,2));
   }
 
   // Vector4
@@ -629,6 +628,8 @@ struct Vector4
     assert(Vector4(1, 2, 3, 4).ZX   == Vector2(3, 1));
     assert(Vector4(1, 2, 3, 4).XZX  == Vector3(1, 3, 1));
     assert(Vector4(1, 2, 3, 4).WZYX == Vector4(4, 3, 2, 1));
+    assert(Vector4(1, 2, 3, 4)._WZYX == Vector4(4, 3, 2, 1));
+    assert(Vector4(1, 2, 3, 4)._0ZYX == Vector4(0, 3, 2, 1));
 
     static assert(!__traits(compiles, Vector4(1, 2, 3, 4).Foo), "Swizzling is only supposed to work with value members of " ~ Vector4.stringof ~ ".");
     static assert(!__traits(compiles, Vector4(1, 2, 3, 4).XXXXX), "Swizzling output dimension is limited to 4.");


### PR DESCRIPTION
Adds a default Vector3 implementation ( `krepel.math.vector3.Vector3` ) to the `krepel.math` module.
A simd version of this code may be created later in a module e.g. `krepel.math.simd`

Progress:
- [x] struct specification
- [x] Initialization
- [x] Addition
- [x] Subtraction
- [x] Dot Product
- [x] Cross Product
- [x] Float Scaling
- [x] Operators
- [x] Normalization
- [x] NaN checks
- [x] Default Values (Forward, Right, Up , UnitScale, Zero)
- [x] Normal Projection
- [x] Plane Projection
- [x] Normal Mirroring
- [x] Unit tests for everything
- [x] Documentation
- [x] Clamping
- [x] Swizzle Operator (dispatch operator?)
- [x] Nearly Equals
