### PR TITLE
Maintenance of the Memory Module

### DIFF
--- a/code/krepel/memory/allocator_interface.d
+++ b/code/krepel/memory/allocator_interface.d
@@ -1,3 +1,7 @@
+/// The general-purpose allocator interface.
+///
+/// This package provides the common allocator interface and functionality
+/// based on it (such as the New!() function).
 module krepel.memory.allocator_interface;
 
 import krepel.memory.common;

--- a/code/krepel/memory/allocator_interface.d
+++ b/code/krepel/memory/allocator_interface.d
@@ -19,11 +19,11 @@ interface IAllocator
 @nogc:
 nothrow:
 
-  bool Contains(in MemoryRegion SomeRegion);
+  bool Contains(in void[] SomeRegion);
 
-  MemoryRegion Allocate(size_t RequestedBytes, size_t Alignment = 0);
+  void[] Allocate(size_t RequestedBytes, size_t Alignment = 0);
 
-  bool Deallocate(MemoryRegion MemoryToDeallocate);
+  bool Deallocate(void[] MemoryToDeallocate);
 }
 
 /// Creates a new instance of Type without constructing it.
@@ -169,9 +169,9 @@ nothrow:
   /// The actual memory to wrap.
   void* WrappedPtr;
 
-  bool Contains(in MemoryRegion SomeRegion) { return false; }
-  MemoryRegion Allocate(size_t RequestedBytes, size_t Alignment = 0) { return null; }
-  bool Deallocate(MemoryRegion MemoryToDeallocate) { return false; }
+  bool Contains(in void[] SomeRegion) { return false; }
+  void[] Allocate(size_t RequestedBytes, size_t Alignment = 0) { return null; }
+  bool Deallocate(void[] MemoryToDeallocate) { return false; }
 }
 
 template Wrap(SomeMemoryType)
@@ -184,19 +184,19 @@ template Wrap(SomeMemoryType)
 
     SomeMemoryType* WrappedPtr;
 
-    final override bool Contains(in MemoryRegion SomeRegion)
+    final override bool Contains(in void[] SomeRegion)
     {
       assert(WrappedPtr);
       return WrappedPtr.Contains(SomeRegion);
     }
 
-    final override MemoryRegion Allocate(size_t RequestedBytes, size_t Alignment = 0)
+    final override void[] Allocate(size_t RequestedBytes, size_t Alignment = 0)
     {
       assert(WrappedPtr);
       return WrappedPtr.Allocate(RequestedBytes, Alignment);
     }
 
-    final override bool Deallocate(MemoryRegion MemoryToDeallocate)
+    final override bool Deallocate(void[] MemoryToDeallocate)
     {
       assert(WrappedPtr);
       return WrappedPtr.Deallocate(MemoryToDeallocate);
@@ -285,14 +285,14 @@ unittest
   assert(cast(void*)SomeAllocator == cast(void*)SomeStack.WrapperMemory.ptr);
 
   auto Mem = SomeAllocator.Allocate(32);
-  Mem[] = 42;
+  (cast(ubyte[])Mem)[] = 42;
 
-  foreach(Byte; SomeStack.Memory[0 .. 32])
+  foreach(Byte; cast(ubyte[])SomeStack.Memory[0 .. 32])
   {
     assert(Byte == 42);
   }
 
-  foreach(Byte; SomeStack.Memory[32 .. $])
+  foreach(Byte; cast(ubyte[])SomeStack.Memory[32 .. $])
   {
     assert(Byte != 42);
   }

--- a/code/krepel/memory/allocator_interface.d
+++ b/code/krepel/memory/allocator_interface.d
@@ -1,0 +1,303 @@
+module krepel.memory.allocator_interface;
+
+import krepel.memory.common;
+import krepel.memory.construction;
+import krepel.memory.allocator_primitives : IsSomeMemory;
+
+/// Global allocator instance.
+IAllocator GlobalAllocator;
+
+/// General allocator interface.
+interface IAllocator
+{
+  @nogc nothrow
+  {
+    bool Contains(in MemoryRegion SomeRegion);
+
+    MemoryRegion Allocate(size_t RequestedBytes, size_t Alignment = 0);
+
+    bool Deallocate(MemoryRegion MemoryToDeallocate);
+  }
+
+  // TODO(Manu): Add @nogc and nothrow for the rest of the interface once Construct and Destruct are compatible.
+
+  /// Creates a new instance of Type without constructing it.
+  final Type* NewUnconstructed(Type)()
+    if(!is(Type == class))
+  {
+    auto Raw = Allocate(Type.sizeof, Type.alignof);
+    if(Raw is null) return null;
+    assert(Raw.length >= Type.sizeof);
+    auto Instance = cast(Type*)Raw.ptr;
+    return Instance;
+  }
+
+  /// Ditto
+  final Type NewUnconstructed(Type)()
+    if(is(Type == class))
+  {
+    enum Size = Meta.ClassInstanceSizeOf!Type;
+    enum Alignment = Meta.ClassInstanceAlignmentOf!Type;
+    auto Raw = Allocate(Size, Alignment);
+    if(Raw is null) return null;
+    assert(Raw.length >= Type.sizeof);
+    auto Instance = cast(Type)Raw.ptr;
+    return Instance;
+  }
+
+  /// Free the memory occupied by Instance without destructing it.
+  /// Note: If the memory type used does not support deallocation
+  ///       (e.g. StackMemory), this function does nothing.
+  final void DeleteUndestructed(Type)(Type* Instance)
+    if(!is(Type == class))
+  {
+    if(Instance)
+    {
+      Deallocate((cast(ubyte*)Instance)[0 .. Type.sizeof]);
+    }
+  }
+
+  /// Ditto
+  final void DeleteUndestructed(Type)(Type Instance)
+    if(is(Type == class))
+  {
+    if(Instance)
+    {
+      Deallocate((cast(ubyte*)Instance)[0 .. Type.sizeof]);
+    }
+  }
+
+  /// Allocate a new instance of type Type and construct it using the given Args.
+  final Type* New(Type, ArgTypes...)(auto ref ArgTypes Args)
+    if(!is(Type == class))
+  {
+    return .Construct(NewUnconstructed!Type(), Args);
+  }
+
+  final Type New(Type, ArgTypes...)(auto ref ArgTypes Args)
+    if(is(Type == class))
+  {
+    static assert(!__traits(isAbstractClass, Type), "Cannot instantiate abstract class.");
+    enum Size = Meta.ClassInstanceSizeOf!Type;
+    enum Alignment = Meta.ClassInstanceAlignmentOf!Type;
+    auto Raw = Allocate(Size, Alignment);
+    if(Raw is null) return null;
+    assert(Raw.length >= Type.sizeof);
+    auto Instance = cast(Type)Raw.ptr;
+
+    .Construct(Instance, Args);
+    return Instance;
+  }
+
+  /// Destruct the given Instance and free the memory occupied by it.
+  /// Note: If the memory type used does not support deallocation
+  ///       (e.g. StackMemory), this function only destructs Instance,
+  ///       but does not free memory.
+  final void Delete(Type)(Type* Instance)
+    if(!is(Type == class))
+  {
+    if(Instance)
+    {
+      .Destruct(Instance);
+      DeleteUndestructed(Instance);
+    }
+  }
+
+  /// Ditto
+  final void Delete(Type)(Type Instance)
+    if(is(Type == class))
+  {
+    if(Instance)
+    {
+      .Destruct(Instance);
+      DeleteUndestructed(Instance);
+    }
+  }
+
+  /// Creates a new array of Type's without constructing them.
+  final Type[] NewUnconstructedArray(Type)(size_t Count)
+  {
+    // TODO(Manu): Implement.
+    auto RawMemory = Allocate(Count * Type.sizeof, Type.alignof);
+
+    // Out of memory?
+    if(RawMemory is null) return null;
+
+    auto Array = cast(Type[])RawMemory[0 .. Count * Type.sizeof];
+    return Array;
+  }
+
+  /// Free the memory occupied by the given Array without destructing its
+  /// elements.
+  /// Note: If the memory type used does not support deallocation
+  ///       (e.g. StackMemory), this function does nothing.
+  final void DeleteUndestructed(Type)(Type[] Array)
+  {
+    Deallocate(cast(ubyte[])Array);
+  }
+
+  /// Creates a new array of Type's and construct each element of it with the
+  /// given Args.
+  final Type[] NewArray(Type, ArgTypes...)(size_t Count, auto ref ArgTypes Args)
+  {
+    auto Array = NewUnconstructedArray!Type(Count);
+    .Construct(Array, Args);
+    return Array;
+  }
+
+  /// Destructs all elements of Array and frees the memory occupied by it.
+  /// Note: If the memory type used does not support deallocation
+  ///       (e.g. StackMemory), this function only destructs Instance,
+  ///       but does not free memory.
+  final void Delete(Type)(Type[] Array)
+  {
+    .Destruct(Array);
+    DeleteUndestructed(Array);
+  }
+}
+
+/// Used to get the size of a minimal IAllocator class instance.
+package class MinimalAllocatorWrapper : IAllocator
+{
+@nogc:
+nothrow:
+
+  /// The actual memory to wrap.
+  void* WrappedPtr;
+
+  bool Contains(in MemoryRegion SomeRegion) { return false; }
+  MemoryRegion Allocate(size_t RequestedBytes, size_t Alignment = 0) { return null; }
+  bool Deallocate(MemoryRegion MemoryToDeallocate) { return false; }
+}
+
+template Wrap(SomeMemoryType)
+  if(IsSomeMemory!SomeMemoryType)
+{
+  class WrapperClass : IAllocator
+  {
+  @nogc:
+  nothrow:
+
+    SomeMemoryType* WrappedPtr;
+
+    final override bool Contains(in MemoryRegion SomeRegion)
+    {
+      assert(WrappedPtr);
+      return WrappedPtr.Contains(SomeRegion);
+    }
+
+    final override MemoryRegion Allocate(size_t RequestedBytes, size_t Alignment = 0)
+    {
+      assert(WrappedPtr);
+      return WrappedPtr.Allocate(RequestedBytes, Alignment);
+    }
+
+    final override bool Deallocate(MemoryRegion MemoryToDeallocate)
+    {
+      assert(WrappedPtr);
+      return WrappedPtr.Deallocate(MemoryToDeallocate);
+    }
+  }
+
+  WrapperClass Wrap(ref SomeMemoryType SomeMemory)
+  {
+    /// Note(Manu): The wrapper class is trivial to construct, so we just do
+    /// it every time without thinking about whether it was already
+    /// constructed or not.
+    auto Wrapper = Construct!WrapperClass(SomeMemory.WrapperMemory);
+    Wrapper.WrappedPtr = &SomeMemory;
+    return Wrapper;
+  }
+}
+
+//
+// Unit Tests
+//
+
+version(unittest) import krepel.memory.allocator_primitives;
+
+// IAllocator tests
+unittest
+{
+  static struct TestData
+  {
+    bool Boolean = true;
+    int Integer = 42;
+
+    ~this()
+    {
+      Integer = 0xDeadBeef;
+    }
+  }
+
+  StaticStackMemory!128 Memory;
+  auto StackAllocator = Wrap(Memory);
+
+  auto Data = StackAllocator.New!TestData(false, 1337);
+  static assert(Meta.IsPointer!(typeof(Data)), "New!() should always return a pointer!");
+  assert(AlignedPointer(Data, TestData.alignof) == Data);
+  assert(Data.Boolean == false);
+  assert(Data.Integer == 1337);
+
+  StackAllocator.Delete(Data);
+  assert(Data.Boolean == false);
+  assert(Data.Integer == 0xDeadBeef);
+
+  Data = StackAllocator.NewUnconstructed!TestData();
+  // StackAllocator's memory is initialized to zero, so all the unconstructed
+  // data we get from it must also be 0.
+  assert(Data.Boolean == false);
+  assert(Data.Integer == 0);
+  Construct(Data);
+  assert(Data.Boolean == true);
+  assert(Data.Integer == 42);
+}
+
+// IAllocator allocating class instances.
+unittest
+{
+  class SuperClass
+  {
+    int Data() { return 42; }
+  }
+
+  class SubClass : SuperClass
+  {
+    override int Data() { return 1337; }
+  }
+
+  StaticStackMemory!128 Memory;
+  auto StackAllocator = Wrap(Memory);
+  SuperClass Instance = StackAllocator.New!SubClass();
+  assert(Instance);
+  assert(Instance.Data == 1337);
+}
+
+// IAllocator
+unittest
+{
+  StaticStackMemory!128 SomeStack;
+  auto SomeAllocator = Wrap(SomeStack);
+  assert(cast(void*)SomeAllocator == cast(void*)SomeStack.WrapperMemory.ptr);
+
+  auto Mem = SomeAllocator.Allocate(32);
+  Mem[] = 42;
+
+  foreach(Byte; SomeStack.Memory[0 .. 32])
+  {
+    assert(Byte == 42);
+  }
+
+  foreach(Byte; SomeStack.Memory[32 .. $])
+  {
+    assert(Byte != 42);
+  }
+
+  static struct Foo
+  {
+    int Bar = 42;
+  }
+
+  assert(SomeAllocator.New!Foo().Bar == 42);
+  assert(*cast(int*)(SomeStack.Memory[32 .. 32 + int.sizeof].ptr) == 42);
+}

--- a/code/krepel/memory/allocator_primitives.d
+++ b/code/krepel/memory/allocator_primitives.d
@@ -1,4 +1,5 @@
-module krepel.memory.allocation;
+/// Primitives for low-level memory management.
+module krepel.memory.allocator_primitives;
 
 import krepel;
 import krepel.memory;
@@ -6,183 +7,6 @@ import krepel.algorithm;
 import krepel.math : IsPowerOfTwo, IsEven, IsOdd;
 import Meta = krepel.meta;
 
-IAllocator GlobalAllocator;
-
-/// Common functionality for all memory types.
-mixin template CommonMemoryStuff()
-{
-  alias ThisIsAMemoryType = typeof(this);
-
-  ubyte[Meta.ClassInstanceSizeOf!MinimalMemoryClass] WrapperMemory = void;
-}
-
-/// Adds the Contains function to a memory type so it can be asked whether a
-/// given memory region belongs to them.
-mixin template MemoryContainsCheckMixin(alias Member)
-{
-  bool Contains(const MemoryRegion SomeRegion) const
-  {
-    bool IsWithinLeftBound  = SomeRegion.ptr >= Member.ptr;
-    bool IsWithinRightBound = SomeRegion.ptr + SomeRegion.length <= Member.ptr + Member.length;
-    return IsWithinLeftBound && IsWithinRightBound;
-  }
-}
-
-/// A template to determine whether the given type is a memory type.
-template IsSomeMemory(M)
-{
-  static if(is(M.ThisIsAMemoryType)) enum bool IsSomeMemory = true;
-  else                               enum bool IsSomeMemory = false;
-}
-
-
-interface IAllocator
-{
-  @nogc nothrow
-  {
-    bool Contains(const MemoryRegion SomeRegion);
-
-    MemoryRegion Allocate(size_t RequestedBytes, size_t Alignment = 0);
-
-    bool Deallocate(MemoryRegion MemoryToDeallocate);
-  }
-
-  // TODO(Manu): Add @nogc and nothrow for the rest of the interface once Construct and Destruct are compatible.
-
-  /// Creates a new instance of Type without constructing it.
-  final Type* NewUnconstructed(Type)()
-    if(!is(Type == class))
-  {
-    auto Raw = Allocate(Type.sizeof, Type.alignof);
-    if(Raw is null) return null;
-    assert(Raw.length >= Type.sizeof);
-    auto Instance = cast(Type*)Raw.ptr;
-    return Instance;
-  }
-
-  /// Ditto
-  final Type NewUnconstructed(Type)()
-    if(is(Type == class))
-  {
-    enum Size = Meta.ClassInstanceSizeOf!Type;
-    enum Alignment = Meta.ClassInstanceAlignmentOf!Type;
-    auto Raw = Allocate(Size, Alignment);
-    if(Raw is null) return null;
-    assert(Raw.length >= Type.sizeof);
-    auto Instance = cast(Type)Raw.ptr;
-    return Instance;
-  }
-
-  /// Free the memory occupied by Instance without destructing it.
-  /// Note: If the memory type used does not support deallocation
-  ///       (e.g. StackMemory), this function does nothing.
-  final void DeleteUndestructed(Type)(Type* Instance)
-    if(!is(Type == class))
-  {
-    if(Instance)
-    {
-      Deallocate((cast(ubyte*)Instance)[0 .. Type.sizeof]);
-    }
-  }
-
-  /// Ditto
-  final void DeleteUndestructed(Type)(Type Instance)
-    if(is(Type == class))
-  {
-    if(Instance)
-    {
-      Deallocate((cast(ubyte*)Instance)[0 .. Type.sizeof]);
-    }
-  }
-
-  /// Allocate a new instance of type Type and construct it using the given Args.
-  final Type* New(Type, ArgTypes...)(auto ref ArgTypes Args)
-    if(!is(Type == class))
-  {
-    return .Construct(NewUnconstructed!Type(), Args);
-  }
-
-  final Type New(Type, ArgTypes...)(auto ref ArgTypes Args)
-    if(is(Type == class))
-  {
-    static assert(!__traits(isAbstractClass, Type), "Cannot instantiate abstract class.");
-    enum Size = Meta.ClassInstanceSizeOf!Type;
-    enum Alignment = Meta.ClassInstanceAlignmentOf!Type;
-    auto Raw = Allocate(Size, Alignment);
-    if(Raw is null) return null;
-    assert(Raw.length >= Type.sizeof);
-    auto Instance = cast(Type)Raw.ptr;
-
-    .Construct(Instance, Args);
-    return Instance;
-  }
-
-  /// Destruct the given Instance and free the memory occupied by it.
-  /// Note: If the memory type used does not support deallocation
-  ///       (e.g. StackMemory), this function only destructs Instance,
-  ///       but does not free memory.
-  final void Delete(Type)(Type* Instance)
-    if(!is(Type == class))
-  {
-    if(Instance)
-    {
-      .Destruct(Instance);
-      DeleteUndestructed(Instance);
-    }
-  }
-
-  /// Ditto
-  final void Delete(Type)(Type Instance)
-    if(is(Type == class))
-  {
-    if(Instance)
-    {
-      .Destruct(Instance);
-      DeleteUndestructed(Instance);
-    }
-  }
-
-  /// Creates a new array of Type's without constructing them.
-  final Type[] NewUnconstructedArray(Type)(size_t Count)
-  {
-    // TODO(Manu): Implement.
-    auto RawMemory = Allocate(Count * Type.sizeof, Type.alignof);
-
-    // Out of memory?
-    if(RawMemory is null) return null;
-
-    auto Array = cast(Type[])RawMemory[0 .. Count * Type.sizeof];
-    return Array;
-  }
-
-  /// Free the memory occupied by the given Array without destructing its
-  /// elements.
-  /// Note: If the memory type used does not support deallocation
-  ///       (e.g. StackMemory), this function does nothing.
-  final void DeleteUndestructed(Type)(Type[] Array)
-  {
-    Deallocate(cast(ubyte[])Array);
-  }
-
-  /// Creates a new array of Type's and construct each element of it with the
-  /// given Args.
-  final Type[] NewArray(Type, ArgTypes...)(size_t Count, auto ref ArgTypes Args)
-  {
-    auto Array = NewUnconstructedArray!Type(Count);
-    .Construct(Array, Args);
-    return Array;
-  }
-
-  /// Destructs all elements of Array and frees the memory occupied by it.
-  /// Note: If the memory type used does not support deallocation
-  ///       (e.g. StackMemory), this function only destructs Instance,
-  ///       but does not free memory.
-  final void Delete(Type)(Type[] Array)
-  {
-    .Destruct(Array);
-    DeleteUndestructed(Array);
-  }
-}
 
 /// Forwards all calls to the appropriate krepel.system.* functions.
 struct SystemMemory
@@ -190,7 +14,7 @@ struct SystemMemory
   @nogc:
   nothrow:
 
-  mixin CommonMemoryStuff;
+  mixin CommonMemoryImplementation;
 
   private import krepel.system;
 
@@ -213,6 +37,12 @@ struct SystemMemory
   bool Deallocate(MemoryRegion MemoryToDeallocate)
   {
     return SystemMemoryDeallocation(MemoryToDeallocate);
+  }
+
+  bool Contains(MemoryRegion SomeRegion)
+  {
+    /// TODO(Manu): Support this somehow?
+    return false;
   }
 }
 
@@ -263,8 +93,8 @@ struct HeapMemory
   /// requests 1 byte of memory with an alignment of 1.
   enum MinimumBlockSize = BlockOverhead + 1;
 
-  mixin CommonMemoryStuff;
-  mixin MemoryContainsCheckMixin!(Memory);
+  mixin CommonMemoryImplementation;
+  mixin Contains_DefaultImplementation!Memory;
 
 
   this(MemoryRegion AvailableMemory)
@@ -484,8 +314,8 @@ struct StackMemory
     IsInitialized = true;
   }
 
-  mixin StackMemoryTemplate;
-  mixin MemoryContainsCheckMixin!(Memory);
+  mixin CommonStackMemoryImplementation;
+  mixin Contains_DefaultImplementation!Memory;
 }
 
 struct StaticStackMemory(size_t N)
@@ -502,14 +332,14 @@ struct StaticStackMemory(size_t N)
 
   enum bool IsInitialized = true;
 
-  mixin StackMemoryTemplate;
-  mixin MemoryContainsCheckMixin!(Memory);
+  mixin CommonStackMemoryImplementation;
+  mixin Contains_DefaultImplementation!Memory;
 }
 
 /// Common functionality for stack memory.
-mixin template StackMemoryTemplate()
+mixin template CommonStackMemoryImplementation()
 {
-  mixin CommonMemoryStuff;
+  mixin CommonMemoryImplementation;
 
   MemoryRegion Allocate(size_t RequestedBytes, size_t Alignment = 0)
   {
@@ -538,89 +368,33 @@ mixin template StackMemoryTemplate()
   }
 }
 
-/// Wraps two other memory types.
-///
-/// When allocating from the first memory fails, it tries the second one.
-struct HybridMemory(P, S)
+
+/// Common functionality for all memory types.
+mixin template CommonMemoryImplementation()
 {
-  alias PrimaryMemoryType = P;
-  alias SecondaryMemoryType = S;
+  alias ThisIsAMemoryType = typeof(this);
 
-  static assert(IsSomeMemory!PrimaryMemoryType && IsSomeMemory!SecondaryMemoryType);
+  private import krepel.memory.allocator_interface : MinimalAllocatorWrapper;
+  ubyte[Meta.ClassInstanceSizeOf!MinimalAllocatorWrapper] WrapperMemory = void;
+}
 
-  PrimaryMemoryType    PrimaryMemory;
-  SecondaryMemoryType  SecondaryMemory;
-
-  mixin CommonMemoryStuff;
-
-
-  auto Allocate(size_t RequestedBytes, size_t Alignment = 0)
+/// Adds the Contains() function to a memory type so it can be asked whether a
+/// given memory region belongs to them.
+mixin template Contains_DefaultImplementation(alias Member)
+{
+  bool Contains(const MemoryRegion SomeRegion) const
   {
-    auto RequestedMemory = PrimaryMemory.Allocate(RequestedBytes, Alignment);
-    if(RequestedMemory.length == RequestedBytes) return RequestedMemory;
-    return SecondaryMemory.Allocate(RequestedBytes, Alignment);
-  }
-
-  bool Deallocate(MemoryRegion MemoryToDeallocate)
-  {
-    if(PrimaryMemory.Contains(MemoryToDeallocate))
-    {
-      return PrimaryMemory.Deallocate(MemoryToDeallocate);
-    }
-    return SecondaryMemory.Deallocate(MemoryToDeallocate);
-  }
-
-  bool Contains(SomeType)(auto ref SomeType Something)
-  {
-    return PrimaryMemory.Contains(Something) || SecondaryMemory.Contains(Something);
+    bool IsWithinLeftBound  = SomeRegion.ptr >= Member.ptr;
+    bool IsWithinRightBound = SomeRegion.ptr + SomeRegion.length <= Member.ptr + Member.length;
+    return IsWithinLeftBound && IsWithinRightBound;
   }
 }
 
-/// Used to get the size of a minimal IAllocator class instance.
-private class MinimalMemoryClass : IAllocator
+/// A template to determine whether the given type is a memory type.
+template IsSomeMemory(M)
 {
-@nogc:
-nothrow:
-
-/// The actual memory to wrap.
-  void* WrappedPtr;
-  bool Contains(const MemoryRegion SomeRegion) { return false; }
-  MemoryRegion Allocate(size_t RequestedBytes, size_t Alignment = 0) { return null; }
-  bool Deallocate(MemoryRegion MemoryToDeallocate) { return false; }
-}
-
-template Wrap(SomeMemoryType)
-  if(IsSomeMemory!SomeMemoryType)
-{
-  class WrapperClass : IAllocator
-  {
-  @nogc:
-  nothrow:
-
-    SomeMemoryType* WrappedPtr;
-
-    final override bool Contains(const MemoryRegion SomeRegion)
-    {
-      return WrappedPtr.Contains(SomeRegion);
-    }
-
-    final override MemoryRegion Allocate(size_t RequestedBytes, size_t Alignment = 0)
-    {
-      return WrappedPtr.Allocate(RequestedBytes, Alignment);
-    }
-
-    final override bool Deallocate(MemoryRegion MemoryToDeallocate)
-    {
-      return WrappedPtr.Deallocate(MemoryToDeallocate);
-    }
-  }
-
-  WrapperClass Wrap(ref SomeMemoryType SomeMemory)
-  {
-    auto Wrapper = Construct!WrapperClass(SomeMemory.WrapperMemory);
-    Wrapper.WrappedPtr = &SomeMemory;
-    return Wrapper;
-  }
+  static if(is(M.ThisIsAMemoryType)) enum bool IsSomeMemory = true;
+  else                               enum bool IsSomeMemory = false;
 }
 
 //
@@ -734,122 +508,4 @@ unittest
   auto Block3 = Stack.Allocate(128);
   assert(Block3 is null);
   assert(Stack.AllocationMark == 32 + 64);
-}
-
-// HybridMemory tests
-unittest
-{
-  ubyte[256] HeapBuffer;
-  auto Stack  = StaticStackMemory!32();
-  auto Heap   = HeapMemory(HeapBuffer[]);
-  auto Hybrid = HybridMemory!(typeof(Stack)*, typeof(Heap)*)(&Stack, &Heap);
-
-  auto Block1 = Hybrid.Allocate(16, 1);
-  assert(Block1);
-  assert(Block1.length == 16);
-  assert(Stack.Contains(Block1));
-  auto Block2 = Hybrid.Allocate(16, 1);
-  assert(Block2.length == 16);
-  assert(Stack.Contains(Block2));
-  auto Block3 = Hybrid.Allocate(16);
-  assert(Block3.length == 16);
-  assert(!Stack.Contains(Block3));
-  assert(Heap.Contains(Block3));
-  auto Block4 = Hybrid.Allocate(16);
-  assert(Block4);
-
-  // Note(Manu): Cannot deallocate Block1 and Block2 since it's a stack
-  // allocator.
-
-  assert(Hybrid.Deallocate(Block3));
-  assert(Hybrid.Deallocate(Block4));
-
-  // TODO(Manu): Test reliably for the out-of-memory case somehow.
-  //assert(Heap.Allocate(1) is null);
-}
-
-// IAllocator tests
-unittest
-{
-  static struct TestData
-  {
-    bool Boolean = true;
-    int Integer = 42;
-
-    ~this()
-    {
-      Integer = 0xDeadBeef;
-    }
-  }
-
-  StaticStackMemory!128 Memory;
-  auto StackAllocator = Wrap(Memory);
-
-  auto Data = StackAllocator.New!TestData(false, 1337);
-  static assert(Meta.IsPointer!(typeof(Data)), "New!() should always return a pointer!");
-  assert(AlignedPointer(Data, TestData.alignof) == Data);
-  assert(Data.Boolean == false);
-  assert(Data.Integer == 1337);
-
-  StackAllocator.Delete(Data);
-  assert(Data.Boolean == false);
-  assert(Data.Integer == 0xDeadBeef);
-
-  Data = StackAllocator.NewUnconstructed!TestData();
-  // StackAllocator's memory is initialized to zero, so all the unconstructed
-  // data we get from it must also be 0.
-  assert(Data.Boolean == false);
-  assert(Data.Integer == 0);
-  Construct(Data);
-  assert(Data.Boolean == true);
-  assert(Data.Integer == 42);
-}
-
-// IAllocator allocating class instances.
-unittest
-{
-  class SuperClass
-  {
-    int Data() { return 42; }
-  }
-
-  class SubClass : SuperClass
-  {
-    override int Data() { return 1337; }
-  }
-
-  StaticStackMemory!128 Memory;
-  auto StackAllocator = Wrap(Memory);
-  SuperClass Instance = StackAllocator.New!SubClass();
-  assert(Instance);
-  assert(Instance.Data == 1337);
-}
-
-// IAllocator
-unittest
-{
-  StaticStackMemory!128 SomeStack;
-  auto SomeAllocator = Wrap(SomeStack);
-  assert(cast(void*)SomeAllocator == cast(void*)SomeStack.WrapperMemory.ptr);
-
-  auto Mem = SomeAllocator.Allocate(32);
-  Mem[] = 42;
-
-  foreach(Byte; SomeStack.Memory[0 .. 32])
-  {
-    assert(Byte == 42);
-  }
-
-  foreach(Byte; SomeStack.Memory[32 .. $])
-  {
-    assert(Byte != 42);
-  }
-
-  static struct Foo
-  {
-    int Bar = 42;
-  }
-
-  assert(SomeAllocator.New!Foo().Bar == 42);
-  assert(*cast(int*)(SomeStack.Memory[32 .. 32 + int.sizeof].ptr) == 42);
 }

--- a/code/krepel/memory/allocator_primitives.d
+++ b/code/krepel/memory/allocator_primitives.d
@@ -141,8 +141,9 @@ struct HeapMemory
     if(Alignment == 0) Alignment = DefaultAlignment;
 
     const RequiredBytes = RequestedBytes + Alignment;
-    debug(HeapMemory) const RequiredBlockSize = BlockOverhead + RequiredBytes + DeadBeefType.sizeof;
-    else                   const RequiredBlockSize = BlockOverhead + RequiredBytes;
+    const PaddingToAchieveAnEvenBlockSize = RequiredBytes.IsEven ? 0 : 1;
+    debug(HeapMemory) const RequiredBlockSize = BlockOverhead + RequiredBytes + PaddingToAchieveAnEvenBlockSize + DeadBeefType.sizeof;
+    else              const RequiredBlockSize = BlockOverhead + RequiredBytes + PaddingToAchieveAnEvenBlockSize;
 
     auto Block = FindFreeBlockAndMergeAdjacent(FirstBlock, RequiredBlockSize);
 

--- a/code/krepel/memory/allocator_primitives.d
+++ b/code/krepel/memory/allocator_primitives.d
@@ -1,4 +1,7 @@
 /// Primitives for low-level memory management.
+///
+/// Naming convention for these primitives is to let their name contain
+/// "Memory", such as "HeapMemory".
 module krepel.memory.allocator_primitives;
 
 import krepel;
@@ -371,12 +374,15 @@ mixin template CommonStackMemoryImplementation()
 
 
 /// Common functionality for all memory types.
+///
+/// You should probably place this mixin last in your struct because it adds
+/// data members to it and will mess up implicit member initialization.
 mixin template CommonMemoryImplementation()
 {
   alias ThisIsAMemoryType = typeof(this);
 
   private import krepel.memory.allocator_interface : MinimalAllocatorWrapper;
-  ubyte[Meta.ClassInstanceSizeOf!MinimalAllocatorWrapper] WrapperMemory = void;
+  package ubyte[Meta.ClassInstanceSizeOf!MinimalAllocatorWrapper] WrapperMemory = void;
 }
 
 /// Adds the Contains() function to a memory type so it can be asked whether a

--- a/code/krepel/memory/allocator_strategies.d
+++ b/code/krepel/memory/allocator_strategies.d
@@ -1,4 +1,9 @@
-/// Higher-level memory management strategies that makes use of krepel.memory.allocator_primitives.
+/// Higher-level memory management strategies that makes use of allocator
+/// primitives found in krepel.memory.allocator_primitives.
+///
+/// Strategy implementations should be named something with "Allocator", such
+/// as "HybridAllocator". This will distringuish the higher level constructs
+/// from allocator primitives, even though they share the same interface.
 module krepel.memory.allocator_strategies;
 
 import krepel.memory.common;
@@ -9,7 +14,7 @@ import krepel.memory.allocator_interface;
 /// Wraps two other memory types.
 ///
 /// When allocating from the first memory fails, it tries the second one.
-struct HybridMemory(P, S)
+struct HybridAllocator(P, S)
 {
   alias PrimaryMemoryType = P;
   alias SecondaryMemoryType = S;
@@ -48,13 +53,13 @@ struct HybridMemory(P, S)
 // Unit Tests
 //
 
-// HybridMemory tests
+// HybridAllocator tests
 unittest
 {
   ubyte[256] HeapBuffer;
   auto Stack  = StaticStackMemory!32();
   auto Heap   = HeapMemory(HeapBuffer[]);
-  auto Hybrid = HybridMemory!(typeof(Stack)*, typeof(Heap)*)(&Stack, &Heap);
+  auto Hybrid = HybridAllocator!(typeof(Stack)*, typeof(Heap)*)(&Stack, &Heap);
 
   auto Block1 = Hybrid.Allocate(16, 1);
   assert(Block1);

--- a/code/krepel/memory/allocator_strategies.d
+++ b/code/krepel/memory/allocator_strategies.d
@@ -1,0 +1,81 @@
+/// Higher-level memory management strategies that makes use of krepel.memory.allocator_primitives.
+module krepel.memory.allocator_strategies;
+
+import krepel.memory.common;
+import krepel.memory.allocator_primitives;
+import krepel.memory.allocator_interface;
+
+
+/// Wraps two other memory types.
+///
+/// When allocating from the first memory fails, it tries the second one.
+struct HybridMemory(P, S)
+{
+  alias PrimaryMemoryType = P;
+  alias SecondaryMemoryType = S;
+
+  static assert(IsSomeMemory!PrimaryMemoryType && IsSomeMemory!SecondaryMemoryType);
+
+  PrimaryMemoryType    PrimaryMemory;
+  SecondaryMemoryType  SecondaryMemory;
+
+  mixin CommonMemoryImplementation;
+
+
+  auto Allocate(size_t RequestedBytes, size_t Alignment = 0)
+  {
+    auto RequestedMemory = PrimaryMemory.Allocate(RequestedBytes, Alignment);
+    if(RequestedMemory.length == RequestedBytes) return RequestedMemory;
+    return SecondaryMemory.Allocate(RequestedBytes, Alignment);
+  }
+
+  bool Deallocate(MemoryRegion MemoryToDeallocate)
+  {
+    if(PrimaryMemory.Contains(MemoryToDeallocate))
+    {
+      return PrimaryMemory.Deallocate(MemoryToDeallocate);
+    }
+    return SecondaryMemory.Deallocate(MemoryToDeallocate);
+  }
+
+  bool Contains(SomeType)(auto ref SomeType Something)
+  {
+    return PrimaryMemory.Contains(Something) || SecondaryMemory.Contains(Something);
+  }
+}
+
+//
+// Unit Tests
+//
+
+// HybridMemory tests
+unittest
+{
+  ubyte[256] HeapBuffer;
+  auto Stack  = StaticStackMemory!32();
+  auto Heap   = HeapMemory(HeapBuffer[]);
+  auto Hybrid = HybridMemory!(typeof(Stack)*, typeof(Heap)*)(&Stack, &Heap);
+
+  auto Block1 = Hybrid.Allocate(16, 1);
+  assert(Block1);
+  assert(Block1.length == 16);
+  assert(Stack.Contains(Block1));
+  auto Block2 = Hybrid.Allocate(16, 1);
+  assert(Block2.length == 16);
+  assert(Stack.Contains(Block2));
+  auto Block3 = Hybrid.Allocate(16);
+  assert(Block3.length == 16);
+  assert(!Stack.Contains(Block3));
+  assert(Heap.Contains(Block3));
+  auto Block4 = Hybrid.Allocate(16);
+  assert(Block4);
+
+  // Note(Manu): Cannot deallocate Block1 and Block2 since it's a stack
+  // allocator.
+
+  assert(Hybrid.Deallocate(Block3));
+  assert(Hybrid.Deallocate(Block4));
+
+  // TODO(Manu): Test reliably for the out-of-memory case somehow.
+  //assert(Heap.Allocate(1) is null);
+}

--- a/code/krepel/memory/allocator_strategies.d
+++ b/code/krepel/memory/allocator_strategies.d
@@ -34,7 +34,7 @@ struct HybridAllocator(P, S)
     return SecondaryMemory.Allocate(RequestedBytes, Alignment);
   }
 
-  bool Deallocate(MemoryRegion MemoryToDeallocate)
+  bool Deallocate(void[] MemoryToDeallocate)
   {
     if(PrimaryMemory.Contains(MemoryToDeallocate))
     {

--- a/code/krepel/memory/common.d
+++ b/code/krepel/memory/common.d
@@ -1,4 +1,4 @@
-module krepel.memory.memory;
+module krepel.memory.common;
 import krepel.math;
 
 @nogc:

--- a/code/krepel/memory/common.d
+++ b/code/krepel/memory/common.d
@@ -17,12 +17,11 @@ alias GB  = (const Bytes) => Bytes * (cast(size_t)1000).MB;
 alias TB  = (const Bytes) => Bytes * (cast(size_t)1000).GB;
 alias PB  = (const Bytes) => Bytes * (cast(size_t)1000).TB;
 
-alias MemoryRegion = ubyte[];
-alias StaticMemoryRegion(size_t N) = ubyte[N];
 
 /// Note: Apparently it's a good idea to have an alignment of 16. See
 ///       https://en.wikipedia.org/wiki/Data_structure_alignment#x86
 enum GlobalDefaultAlignment = 16;
+
 
 auto AlignedSize(const size_t Size, const size_t Alignment)
 {

--- a/code/krepel/memory/construction.d
+++ b/code/krepel/memory/construction.d
@@ -66,16 +66,19 @@ void Destruct(Type)(Type* Instance)
       // Destruct all the members of Instance.
       foreach(MemberName; __traits(allMembers, Type))
       {
-        alias MemberType = typeof(mixin(`Instance.` ~ MemberName));
-        static if(Meta.HasDestructor!MemberType)
+        static if(__traits(compiles, typeof(mixin(`Instance.` ~ MemberName))))
         {
-          static if(is(MemberType == class))
+          alias MemberType = typeof(mixin(`Instance.` ~ MemberName));
+          static if(Meta.HasDestructor!MemberType)
           {
-            Destruct(mixin(`Instance.` ~ MemberName));
-          }
-          else
-          {
-            Destruct(mixin(`&Instance.` ~ MemberName));
+            static if(is(MemberType == class))
+            {
+              Destruct(mixin(`Instance.` ~ MemberName));
+            }
+            else
+            {
+              Destruct(mixin(`&Instance.` ~ MemberName));
+            }
           }
         }
       }

--- a/code/krepel/memory/construction.d
+++ b/code/krepel/memory/construction.d
@@ -13,22 +13,22 @@ private static import std.conv;
 // pure:
 
 
-Type Construct(Type, ArgTypes...)(MemoryRegion RawMemory, auto ref ArgTypes Args)
+Type Construct(Type, ArgTypes...)(void[] RawMemory, auto ref ArgTypes Args)
   if(is(Type == class))
 {
-  return std.conv.emplace!Type(cast(void[])RawMemory, Args);
+  return std.conv.emplace!Type(RawMemory, Args);
 }
 
-Type* Construct(Type, ArgTypes...)(MemoryRegion RawMemory, auto ref ArgTypes Args)
+Type* Construct(Type, ArgTypes...)(void[] RawMemory, auto ref ArgTypes Args)
   if(!is(Type == class))
 {
-  return std.conv.emplace!Type(cast(void[])RawMemory, Args);
+  return std.conv.emplace!Type(RawMemory, Args);
 }
 
 Type Construct(Type, ArgTypes...)(Type Instance, auto ref ArgTypes Args)
   if(is(Type == class))
 {
-  MemoryRegion RawMemory = (cast(ubyte*)Instance)[0 .. Meta.ClassInstanceSizeOf!Type];
+  void[] RawMemory = (cast(void*)Instance)[0 .. Meta.ClassInstanceSizeOf!Type];
   return Construct!Type(RawMemory, Args);
 }
 

--- a/code/krepel/memory/ownership.d
+++ b/code/krepel/memory/ownership.d
@@ -1,3 +1,4 @@
+deprecated("This module is not ready for use yet.")
 module krepel.memory.ownership;
 
 nothrow:

--- a/code/krepel/memory/package.d
+++ b/code/krepel/memory/package.d
@@ -1,6 +1,8 @@
 module krepel.memory;
 
-public import krepel.memory.memory;
-public import krepel.memory.ownership;
-public import krepel.memory.allocation;
+public import krepel.memory.common;
+//public import krepel.memory.ownership;
 public import krepel.memory.construction;
+public import krepel.memory.allocator_primitives;
+public import krepel.memory.allocator_strategies;
+public import krepel.memory.allocator_interface;


### PR DESCRIPTION
This does some cleanup / refactoring / documentation of `krepel.memory`.

I've renamed the submodules to reflect the intent behind their contents a bit.

I've also changed from `MemoryRegion` to plain `void[]` since in D it does exactly what one would want.

Other than that I did some cleanup here and there and also cherry-picked in that one commit that got lost during some merge one day... It haunts me! I hope the change will stay in, finally.......
