### PR TITLE
AutoHeap now calculates the overhead needed for the HeapMemory.

### DIFF
--- a/code/krepel/memory/allocator_strategies.d
+++ b/code/krepel/memory/allocator_strategies.d
@@ -87,8 +87,8 @@ struct AutoHeapAllocator
     EnsureValidState();
 
     // TODO(Manu): assert(RequestedBytes < HeapSize)?
-    const NewHeapSize = Max(RequestedBytes, HeapSize);
     auto NewHeap = &Heaps.Expand();
+    const NewHeapSize = NewHeap.CalculateRequiredBlockSize(Max(RequestedBytes, HeapSize), Alignment);
     auto NewHeapMemory = Allocator.Allocate(NewHeapSize, 1);
     NewHeap.Initialize(NewHeapMemory);
 


### PR DESCRIPTION
The autoheap now calculates the overhead needed for the heap management, so any size of allocation can be done using the autoheap allocator as long there is memory available from the parent.
