### PR TITLE
Reference counting

### DIFF
--- a/code/krepel/memory/allocator_interface.d
+++ b/code/krepel/memory/allocator_interface.d
@@ -33,6 +33,7 @@ Type* NewUnconstructed(Type)(IAllocator Allocator)
 Type NewUnconstructed(Type)(IAllocator Allocator)
   if(is(Type == class))
 {
+  static assert(!__traits(isAbstractClass, Type), "Cannot instantiate abstract class.");
   enum Size = Meta.ClassInstanceSizeOf!Type;
   enum Alignment = Meta.ClassInstanceAlignmentOf!Type;
   auto Raw = Allocator.Allocate(Size, Alignment);
@@ -74,16 +75,7 @@ Type* New(Type, ArgTypes...)(IAllocator Allocator, auto ref ArgTypes Args)
 Type New(Type, ArgTypes...)(IAllocator Allocator, auto ref ArgTypes Args)
   if(is(Type == class))
 {
-  static assert(!__traits(isAbstractClass, Type), "Cannot instantiate abstract class.");
-  enum Size = Meta.ClassInstanceSizeOf!Type;
-  enum Alignment = Meta.ClassInstanceAlignmentOf!Type;
-  auto Raw = Allocator.Allocate(Size, Alignment);
-  if(Raw is null) return null;
-  assert(Raw.length >= Type.sizeof);
-  auto Instance = cast(Type)Raw.ptr;
-
-  Construct(Instance, Args);
-  return Instance;
+  return Construct(Allocator.NewUnconstructed!Type(), Args);
 }
 
 /// Destruct the given Instance and free the memory occupied by it.

--- a/code/krepel/memory/package.d
+++ b/code/krepel/memory/package.d
@@ -6,3 +6,4 @@ public import krepel.memory.construction;
 public import krepel.memory.allocator_primitives;
 public import krepel.memory.allocator_strategies;
 public import krepel.memory.allocator_interface;
+public import krepel.memory.reference_counting;

--- a/code/krepel/memory/reference_counting.d
+++ b/code/krepel/memory/reference_counting.d
@@ -174,4 +174,16 @@ unittest
 
   assert(Object.RefCount == 0);
   assert(Object.Foo == 94);
+
+  {
+    auto WrappedObject = TestAllocator.NewARC!(TestObject, RefCountMode.External);
+    assert(WrappedObject.RefCount == 1);
+    assert(WrappedObject.Foo == 42);
+
+    Object = WrappedObject;
+    assert(WrappedObject.RefCountPayload !is Object.RefCountPayload);
+    assert(Object.RefCount == 0);
+  }
+
+  assert(Object.Foo == 94);
 }

--- a/code/krepel/memory/reference_counting.d
+++ b/code/krepel/memory/reference_counting.d
@@ -1,0 +1,129 @@
+module krepel.memory.reference_counting;
+
+import krepel.memory.construction;
+import krepel.memory.allocator_interface;
+import Meta = krepel.meta;
+
+/// Allocation data for reference counted objects.
+class ARCData(Type)
+{
+  IAllocator Allocator;
+  long RefCount;
+  InPlace!Type.Data Instance;
+
+  this(IAllocator Allocator, long InitialRefCount)
+  {
+    this.Allocator = Allocator;
+    this.RefCount = InitialRefCount;
+  }
+
+  void AddRef()
+  {
+    // TODO(Manu): Thread safety.unt)++;
+
+    RefCount++;
+  }
+
+  void RemoveRef()
+  {
+    // TODO(Manu): Thread safety.
+
+    RefCount--;
+
+    assert(RefCount >= 0, "Invalid reference count.");
+    if(RefCount <= 0)
+    {
+      InPlace!Type.Destruct(Instance);
+      Allocator.Delete(this);
+    }
+  }
+}
+
+/// Pointer-like wrapper for reference-counted objects.
+struct ARC(Type)
+{
+  ARCData!Type _Data;
+
+  @property inout(Type) _Instance() inout
+  {
+    assert(_Data);
+    return _Data.Instance;
+  }
+
+  this(this)
+  {
+    assert(_Data);
+    _Data.AddRef();
+  }
+
+  ~this()
+  {
+    assert(_Data);
+    _Data.RemoveRef();
+  }
+
+  alias _Instance this;
+}
+
+@property auto RefCount(Type)(ref in ARC!Type Object)
+{
+  return Object._Data.RefCount;
+}
+
+/// Allocates an automatically reference-counted object and initializes it
+/// with the given arguments.
+ARC!Type NewARC(Type, ArgTypes...)(IAllocator Allocator, auto ref ArgTypes Args)
+  if(is(Type == class))
+{
+  auto Data = Allocator.New!(ARCData!Type)(Allocator, 1);
+  InPlace!Type.Construct(Data.Instance, Args);
+  auto Result = ARC!Type(Data);
+  return Result;
+}
+
+//
+// Unit Tests
+//
+
+version(unittest) import krepel.memory : CreateTestAllocator;
+
+// NewARC
+unittest
+{
+  class TestObject
+  {
+    int Foo = 42;
+    float Bar;
+
+    this(int* Message)
+    {
+      assert(Message);
+      *Message += 1;
+    }
+
+    ~this()
+    {
+      Bar = 3.1415f;
+    }
+  }
+
+  auto TestAllocator = CreateTestAllocator();
+
+  ARCData!TestObject* ObjectData;
+
+  {
+    int Message;
+    auto WrappedObject = TestAllocator.NewARC!TestObject(&Message);
+    assert(Message == 1);
+    assert(WrappedObject.Foo == 42);
+    import krepel.math : IsNaN;
+    assert(WrappedObject.Bar.IsNaN);
+
+    ObjectData = &WrappedObject._Data;
+    assert(ObjectData.RefCount == 1);
+  }
+
+  assert(ObjectData.RefCount == 0);
+  assert(ObjectData.Instance.Foo == 42);
+  assert(ObjectData.Instance.Bar == 3.1415f);
+}

--- a/code/krepel/memory/reference_counting.d
+++ b/code/krepel/memory/reference_counting.d
@@ -103,11 +103,12 @@ ARC!Type NewARC(Type, ArgTypes...)(IAllocator Allocator, auto ref ArgTypes Args)
 // Unit Tests
 //
 
-version(unittest) import krepel.memory : CreateTestAllocator;
 
 // NewARC for external reference counting
 unittest
 {
+  import krepel.memory : CreateTestAllocator;
+
   class TestObject
   {
     int Foo = 42;
@@ -149,6 +150,8 @@ unittest
 // NewARC for intrusive reference counting
 unittest
 {
+  import krepel.memory : CreateTestAllocator;
+
   class TestObject
   {
     RefCountPayloadData RefCountPayload;

--- a/code/krepel/meta.d
+++ b/code/krepel/meta.d
@@ -212,6 +212,24 @@ alias ElementType = std.range.ElementType;
 /// }
 alias Bitfields  = std.bitmanip.bitfields;
 
+/// Get the sequence of template arguments given to Type. Type MUST be a
+/// template.
+///
+/// Example:
+///   // Pseudo code:
+///   assert(TemplateArguments!( Foo!(A, B, C) ) == AliasSequence!(A, B, C));
+template TemplateArguments(Type)
+{
+  static if(is(Type : Type!Inner, Inner...))
+  {
+    alias TemplateArguments = Inner;
+  }
+  else
+  {
+    alias TemplateArguments = AliasSequence!();
+  }
+}
+
 
 //
 // Unit Tests


### PR DESCRIPTION
- [x] Automatic reference counting (ARC) using pointer-like wrappers and such.
  - [x] `class`-support.
  - [ ] `struct`-support.
- [x] Ownership functionality combined with ARC. This also means removing/replacing the old module `krepel.memoy.ownership`
- [x] Possiblity to store `ARC!Type` in structs or pass them as arguments.
