### PR TITLE
Add common used modules to krepel module publicly

### DIFF
--- a/code/krepel/package.d
+++ b/code/krepel/package.d
@@ -2,3 +2,6 @@ module krepel;
 
 public import krepel.krepel;
 public import krepel.memory;
+public import krepel.string;
+public import krepel.math;
+public import krepel.container;


### PR DESCRIPTION
Adds
- `krepel.string`
- `krepel.math`
- `krepel.container`

to public import list of the `krepel` module
