### PR TITLE
SDLang Enhancements 1

### DIFF
--- a/code/krepel.build.d
+++ b/code/krepel.build.d
@@ -4,10 +4,23 @@ import build;
 
 immutable thisDir = dirName(__FILE__);
 
-mixin AddBuildRule!("krepel_tests", Tests);
+mixin AddBuildRule!("krepel_tests", BuildAndRun);
+mixin AddBuildRule!("krepel_tests_build_only", Build);
 
+void Build(ref BuildContext Context)
+{
+  DoBuild(Context);
+}
 
-void Tests(ref BuildContext Context)
+void BuildAndRun(ref BuildContext Context)
+{
+  if(DoBuild(Context))
+  {
+    Run(Context);
+  }
+}
+
+bool DoBuild(ref BuildContext Context)
 {
   with(Context)
   {
@@ -32,8 +45,5 @@ void Tests(ref BuildContext Context)
     BuildArgs ~= "-main";
   }
 
-  if(Compile(Context).CompilerStatus == 0)
-  {
-    Run(Context);
-  }
+  return Compile(Context).CompilerStatus == 0;
 }

--- a/code/krepel.build.d
+++ b/code/krepel.build.d
@@ -4,23 +4,33 @@ import build;
 
 immutable thisDir = dirName(__FILE__);
 
-mixin AddBuildRule!("krepel_tests", BuildAndRun);
-mixin AddBuildRule!("krepel_tests_build_only", Build);
+mixin AddBuildRule!("krepel_tests", KrepelTests_BuildAndRun);
+mixin AddBuildRule!("krepel_tests_build_only", KrepelTests_BuildOnly);
+mixin AddBuildRule!("krepel_tests_run_only", KrepelTests_RunOnly);
 
-void Build(ref BuildContext Context)
+void KrepelTests_BuildAndRun(ref BuildContext Context)
 {
-  DoBuild(Context);
-}
+  Prepare(Context);
 
-void BuildAndRun(ref BuildContext Context)
-{
-  if(DoBuild(Context))
+  if(Compile(Context).CompilerStatus == 0)
   {
     Run(Context);
   }
 }
 
-bool DoBuild(ref BuildContext Context)
+void KrepelTests_BuildOnly(ref BuildContext Context)
+{
+  Prepare(Context);
+  Compile(Context);
+}
+
+void KrepelTests_RunOnly(ref BuildContext Context)
+{
+  Prepare(Context);
+  Run(Context);
+}
+
+private void Prepare(ref BuildContext Context)
 {
   with(Context)
   {
@@ -44,6 +54,4 @@ bool DoBuild(ref BuildContext Context)
     BuildArgs ~= "-unittest";
     BuildArgs ~= "-main";
   }
-
-  return Compile(Context).CompilerStatus == 0;
 }

--- a/code/krepel/container/array.d
+++ b/code/krepel/container/array.d
@@ -50,8 +50,8 @@ struct Array(T)
     {
       auto NewMemory = Allocator.NewUnconstructedArray!ElementType(Capacity);
       NewMemory[0..Count] = Data[0..Count];
-      Data = NewMemory;
-      AvailableMemory = Data;
+      Data = NewMemory[0..Count];
+      AvailableMemory = NewMemory;
     }
   }
 

--- a/code/krepel/serialization/Spec.md
+++ b/code/krepel/serialization/Spec.md
@@ -1,0 +1,38 @@
+# SDL Query Sub-Language
+
+Supported by the API and used to query for nodes, attributes, and values within a SDL document in a concise way.
+
+## Specification
+
+Specified in the [Extended Backus–Naur Form](https://en.wikipedia.org/wiki/Extended_Backus%E2%80%93Naur_Form) below.
+
+```
+AnyChar = ? Any UTF-8 character ?
+
+DigitWithoutZero = "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
+Digit = "0" | DigitWithoutZero
+PositiveNumber = DigitWithoutZero, {Digit}
+
+SpecialChar = "!" | '' | "#" | "$" | "%" | "&" | "'" |
+              "(" | ")" | "*" | "+" | "," | "-" | "." |
+              "/" | ":" | ";" | "<" | "=" | ">" | "?" |
+              "@" | "[" | "\" | "]" | "^" | "_" | "`" |
+              "{" | "|" | "}" | "~"
+
+IdentChar = ? AnyChar without SpecialChar and Digit ?
+
+Identifier = ( IdentChar | "_" ), { IdentChar | "_" | Digit };
+
+NodeSpec = Identifier, [ "[", PositiveNumber, "]" ]
+AttributeSpec = "@", Identifier
+ValueSpec = "#", PositiveNumber
+
+Query = NodeSpec, [{ "/", NodeSpec }], ([ AttributeSpec ] | [ ValueSpec ]);
+```
+
+## Examples
+
+| Query String | Equivalent Query | Result |
+| ------------ | ---------------- | ------ |
+| `Foo/Bar` | `Foo[0]/Bar[0]#0` | Look for the first node called "Foo", find its first "Bar" child and fetch the first value of it. |
+| `Foo@Bar` | `Foo[0]@Bar` | Find the first node called "Foo" and look for its attribute called "Bar" and return its value. |

--- a/code/krepel/serialization/sdlang.d
+++ b/code/krepel/serialization/sdlang.d
@@ -973,14 +973,11 @@ unittest
 // Parse simple document
 unittest
 {
-  SystemMemory System;
-  auto Stack = StackMemory(System.Allocate(2.MiB, 1));
-  scope(exit) System.Deallocate(Stack.Memory);
-  auto StackAllocator = Wrap(Stack);
+  auto TestAllocator = CreateTestAllocator!StackMemory();
 
   auto Context = SDLParsingContext("SDL Test 5", .Log);
 
-  auto Document = StackAllocator.New!SDLDocument(StackAllocator);
+  auto Document = TestAllocator.New!SDLDocument(TestAllocator);
   Document.ParseDocumentFromString(`foo "bar"`, Context);
 
   auto Node = Document.FirstChild;
@@ -994,14 +991,11 @@ unittest
 // Parse simple document with attributes
 unittest
 {
-  SystemMemory System;
-  auto Stack = StackMemory(System.Allocate(2.MiB, 1));
-  scope(exit) System.Deallocate(Stack.Memory);
-  auto StackAllocator = Wrap(Stack);
+  auto TestAllocator = CreateTestAllocator!StackMemory();
 
   auto Context = SDLParsingContext("SDL Test 6", .Log);
 
-  auto Document = StackAllocator.New!SDLDocument(StackAllocator);
+  auto Document = TestAllocator.New!SDLDocument(TestAllocator);
   Document.ParseDocumentFromString(`foo "bar" baz="qux"`, Context);
 
   auto Node = Document.FirstChild;
@@ -1019,14 +1013,11 @@ unittest
 // Parse document with multiple nodes
 unittest
 {
-  SystemMemory System;
-  auto Stack = StackMemory(System.Allocate(2.MiB, 1));
-  scope(exit) System.Deallocate(Stack.Memory);
-  auto StackAllocator = Wrap(Stack);
+  auto TestAllocator = CreateTestAllocator!StackMemory();
 
   auto Context = SDLParsingContext("SDL Test 7", .Log);
 
-  auto Document = StackAllocator.New!SDLDocument(StackAllocator);
+  auto Document = TestAllocator.New!SDLDocument(TestAllocator);
   auto Source = q"(
     foo "bar"
     baz "qux"
@@ -1051,14 +1042,11 @@ unittest
 // Parse document with child nodes
 unittest
 {
-  SystemMemory System;
-  auto Stack = StackMemory(System.Allocate(2.MiB, 1));
-  scope(exit) System.Deallocate(Stack.Memory);
-  auto StackAllocator = Wrap(Stack);
+  auto TestAllocator = CreateTestAllocator!StackMemory();
 
   auto Context = SDLParsingContext("SDL Test 8", .Log);
 
-  auto Document = StackAllocator.New!SDLDocument(StackAllocator);
+  auto Document = TestAllocator.New!SDLDocument(TestAllocator);
   auto Source = q"(
     foo "bar" {
       baz "qux" {
@@ -1092,14 +1080,11 @@ unittest
 
 unittest
 {
-  SystemMemory System;
-  auto Stack = StackMemory(System.Allocate(2.MiB, 1));
-  scope(exit) System.Deallocate(Stack.Memory);
-  auto StackAllocator = Wrap(Stack);
+  auto TestAllocator = CreateTestAllocator!StackMemory();
 
   auto Context = SDLParsingContext("SDL Test 9", .Log);
 
-  auto Document = StackAllocator.New!SDLDocument(StackAllocator);
+  auto Document = TestAllocator.New!SDLDocument(TestAllocator);
   Document.ParseDocumentFromString(`answer 42`, Context);
 
   auto Node = Document.FirstChild;
@@ -1293,22 +1278,19 @@ unittest
     assert(!Node.Next.IsValidHandle);
   }
 
-  SystemMemory System;
-  auto Stack = StackMemory(System.Allocate(2.MiB, 1));
-  scope(exit) System.Deallocate(Stack.Memory);
-  auto StackAllocator = Wrap(Stack);
+  auto TestAllocator = CreateTestAllocator!StackMemory();
 
   auto FileName = "../unittest/sdlang/full.sdl"w;
-  auto File = OpenFile(StackAllocator, FileName);
-  scope(exit) CloseFile(StackAllocator, File);
+  auto File = OpenFile(TestAllocator, FileName);
+  scope(exit) CloseFile(TestAllocator, File);
 
   // TODO(Manu): Once we have WString => UString conversion, use the filename
   // as context.
   auto Context = SDLParsingContext("Full", .Log);
-  auto Document = StackAllocator.New!SDLDocument(StackAllocator);
+  auto Document = TestAllocator.New!SDLDocument(TestAllocator);
 
-  scope(exit) StackAllocator.Delete(Document);
-  auto SourceString = StackAllocator.NewArray!char(File.Size);
+  scope(exit) TestAllocator.Delete(Document);
+  auto SourceString = TestAllocator.NewArray!char(File.Size);
   auto BytesRead = File.Read(SourceString);
   assert(BytesRead == SourceString.length);
   assert(Document.ParseDocumentFromString(cast(string)SourceString, Context), SourceString);
@@ -1324,7 +1306,7 @@ unittest
 version(none)
 unittest
 {
-  auto TestAllocator = CreateTestAllocator();
+  auto TestAllocator = CreateTestAllocator!StackMemory();
 
   const SourceString = q"(
     foo "bar" {

--- a/code/krepel/serialization/sdlang.d
+++ b/code/krepel/serialization/sdlang.d
@@ -269,19 +269,19 @@ struct SourceData
   alias CurrentValue this;
 }
 
-bool IsAtWhiteSpace(ref SourceData Source, ref ParsingContext Context)
+bool IsAtWhiteSpace(ref SourceData Source, ref SDLParsingContext Context)
 {
   auto String = Source[];
   return String.length && String.front.IsWhite;
 }
 
-bool IsAtNewLine(ref SourceData Source, ref ParsingContext Context)
+bool IsAtNewLine(ref SourceData Source, ref SDLParsingContext Context)
 {
   auto String = Source[];
   return String.length && String.StartsWith("\n");
 }
 
-SourceData SkipWhiteSpace(ref SourceData OriginalSource, ref ParsingContext Context,
+SourceData SkipWhiteSpace(ref SourceData OriginalSource, ref SDLParsingContext Context,
                           Flag!"ConsumeNewLine" ConsumeNewLine)
 {
   auto Source = OriginalSource;
@@ -296,7 +296,7 @@ SourceData SkipWhiteSpace(ref SourceData OriginalSource, ref ParsingContext Cont
   return OriginalSource.AdvanceBy(NumToAdvance);
 }
 
-bool IsAtLineComment(ref SourceData Source, ref ParsingContext Context)
+bool IsAtLineComment(ref SourceData Source, ref SDLParsingContext Context)
 {
   auto String = Source[];
   return String.StartsWith("//") ||
@@ -304,18 +304,18 @@ bool IsAtLineComment(ref SourceData Source, ref ParsingContext Context)
          String.StartsWith("--");
 }
 
-bool IsAtMultiLineComment(ref SourceData Source, ref ParsingContext Context)
+bool IsAtMultiLineComment(ref SourceData Source, ref SDLParsingContext Context)
 {
   auto String = Source[];
   return String.StartsWith("/*");
 }
 
-bool IsAtComment(ref SourceData Source, ref ParsingContext Context)
+bool IsAtComment(ref SourceData Source, ref SDLParsingContext Context)
 {
   return Source.IsAtLineComment(Context) || Source.IsAtMultiLineComment(Context);
 }
 
-SourceData SkipComments(ref SourceData OriginalSource, ref ParsingContext Context)
+SourceData SkipComments(ref SourceData OriginalSource, ref SDLParsingContext Context)
 {
   auto Source = OriginalSource;
 
@@ -342,7 +342,7 @@ SourceData SkipComments(ref SourceData OriginalSource, ref ParsingContext Contex
   return OriginalSource.AdvanceBy(NumToSkip);
 }
 
-SourceData SkipWhiteSpaceAndComments(ref SourceData OriginalSource, ref ParsingContext Context,
+SourceData SkipWhiteSpaceAndComments(ref SourceData OriginalSource, ref SDLParsingContext Context,
                                      Flag!"ConsumeNewLine" ConsumeNewLine)
 {
   auto Source = OriginalSource;
@@ -369,12 +369,12 @@ SourceData SkipWhiteSpaceAndComments(ref SourceData OriginalSource, ref ParsingC
 }
 
 /// Basically a new-line character or a semi-colon
-bool IsAtSemanticLineDelimiter(ref SourceData Source, ref ParsingContext Context)
+bool IsAtSemanticLineDelimiter(ref SourceData Source, ref SDLParsingContext Context)
 {
   return Source.length && Source.IsAtNewLine(Context) || Source.front == ';';
 }
 
-SourceData ParseUntil(alias Predicate)(ref SourceData Source, ref ParsingContext Context,)
+SourceData ParseUntil(alias Predicate)(ref SourceData Source, ref SDLParsingContext Context,)
 {
   const MaxNum = Source.length;
   size_t NumToAdvance;
@@ -392,7 +392,7 @@ SourceData ParseUntil(alias Predicate)(ref SourceData Source, ref ParsingContext
   return Source.AdvanceBy(NumToAdvance);
 }
 
-SourceData ParseNested(ref SourceData Source, ref ParsingContext Context,
+SourceData ParseNested(ref SourceData Source, ref SDLParsingContext Context,
                        string OpeningSequence, string ClosingSequence,
                        bool* OutFoundClosingSequence = null, int Depth = 1)
 {
@@ -428,7 +428,7 @@ SourceData ParseNested(ref SourceData Source, ref ParsingContext Context,
   return Result;
 }
 
-SourceData ParseEscaped(ref SourceData Source, ref ParsingContext Context,
+SourceData ParseEscaped(ref SourceData Source, ref SDLParsingContext Context,
                         dchar EscapeDelimiter, string DelimiterSequence, Flag!"ConsumeNewLine" ConsumeNewLine)
 {
   const MaxNum = Source.length;
@@ -458,7 +458,7 @@ SourceData ParseEscaped(ref SourceData Source, ref ParsingContext Context,
   return Result;
 }
 
-struct ParsingContext
+struct SDLParsingContext
 {
   /// An identifier for the string source, e.g. a file name. Used in log
   /// messages.
@@ -468,7 +468,7 @@ struct ParsingContext
 }
 
 /// Convenience overload to accept a plain string instead of SourceData.
-bool ParseDocumentFromString(SDLDocument Document, string SourceString, ref ParsingContext Context)
+bool ParseDocumentFromString(SDLDocument Document, string SourceString, ref SDLParsingContext Context)
 {
   auto Source = SourceData(SourceString);
   with(Source.StartLocation) { Line = 1; Column = 1; SourceIndex = 0; }
@@ -477,12 +477,12 @@ bool ParseDocumentFromString(SDLDocument Document, string SourceString, ref Pars
   return Document.ParseDocumentFromSource(Source, Context);
 }
 
-bool ParseDocumentFromSource(SDLDocument Document, ref SourceData Source, ref ParsingContext Context)
+bool ParseDocumentFromSource(SDLDocument Document, ref SourceData Source, ref SDLParsingContext Context)
 {
   return Document.ParseInnerNodes(Source, Context, &Document._FirstChild);
 }
 
-bool ParseInnerNodes(SDLDocument Document, ref SourceData Source, ref ParsingContext Context,
+bool ParseInnerNodes(SDLDocument Document, ref SourceData Source, ref SDLParsingContext Context,
                      SDLNodeRef* FirstNode)
 {
   if(FirstNode is null)
@@ -544,7 +544,7 @@ bool ParseInnerNodes(SDLDocument Document, ref SourceData Source, ref ParsingCon
 
 bool ParseIdentifier(SDLDocument Document,
                      ref SourceData OriginalSource,
-                     ref ParsingContext Context,
+                     ref SDLParsingContext Context,
                      SDLIdentifier* Result)
 {
   auto Source = OriginalSource;
@@ -581,7 +581,7 @@ bool ParseIdentifier(SDLDocument Document,
 
 bool ParseNode(SDLDocument Document,
                ref SourceData OriginalSource,
-               ref ParsingContext Context,
+               ref SDLParsingContext Context,
                SDLNodeRef* OutNode)
 {
   auto Source = OriginalSource;
@@ -697,7 +697,7 @@ bool ParseNode(SDLDocument Document,
 
 bool ParseLiteral(SDLDocument Document,
                   ref SourceData OriginalSource,
-                  ref ParsingContext Context,
+                  ref SDLParsingContext Context,
                   SDLLiteral* OutLiteral)
 {
   auto Source = OriginalSource;
@@ -780,7 +780,7 @@ bool ParseLiteral(SDLDocument Document,
 
 bool ParseAttribute(SDLDocument Document,
                     ref SourceData OriginalSource,
-                    ref ParsingContext Context,
+                    ref SDLParsingContext Context,
                     SDLAttribute* OutAttribute)
 {
   auto Source = OriginalSource;
@@ -848,7 +848,7 @@ MalformedAttribute:
 
 bool ParseNamespaceAndName(SDLDocument Document,
                            ref SourceData OriginalSource,
-                           ref ParsingContext Context,
+                           ref SDLParsingContext Context,
                            SDLIdentifier* OutNamespace,
                            SDLIdentifier* OutName)
 {
@@ -921,7 +921,7 @@ version(unittest) private auto MakeSourceDataForTesting(string Value, size_t Off
 // SkipWhiteSpaceAndComments
 unittest
 {
-  auto Context = ParsingContext("SDL Test 1", .Log);
+  auto Context = SDLParsingContext("SDL Test 1", .Log);
 
   {
     auto Source = MakeSourceDataForTesting("// hello\nworld", 0);
@@ -960,7 +960,7 @@ text)", 0);
 // ParseUntil
 unittest
 {
-  auto Context = ParsingContext("SDL Test 2", .Log);
+  auto Context = SDLParsingContext("SDL Test 2", .Log);
 
   {
     auto Source = MakeSourceDataForTesting(`foo "bar"`, 0);
@@ -976,7 +976,7 @@ unittest
 // ParseNested
 unittest
 {
-  auto Context = ParsingContext("SDL Test 3", .Log);
+  auto Context = SDLParsingContext("SDL Test 3", .Log);
 
   {
     auto Source = MakeSourceDataForTesting(`foo { bar }; baz`, 5);
@@ -1001,7 +1001,7 @@ unittest
 // ParseEscaped
 unittest
 {
-  auto Context = ParsingContext("SDL Test 4", .Log);
+  auto Context = SDLParsingContext("SDL Test 4", .Log);
 
   {
     auto Source = MakeSourceDataForTesting(`foo "bar" "baz"`, 5);
@@ -1032,7 +1032,7 @@ unittest
   scope(exit) System.Deallocate(Stack.Memory);
   auto StackAllocator = Wrap(Stack);
 
-  auto Context = ParsingContext("SDL Test 5", .Log);
+  auto Context = SDLParsingContext("SDL Test 5", .Log);
 
   auto Document = StackAllocator.New!SDLDocument(StackAllocator);
   Document.ParseDocumentFromString(`foo "bar"`, Context);
@@ -1053,7 +1053,7 @@ unittest
   scope(exit) System.Deallocate(Stack.Memory);
   auto StackAllocator = Wrap(Stack);
 
-  auto Context = ParsingContext("SDL Test 6", .Log);
+  auto Context = SDLParsingContext("SDL Test 6", .Log);
 
   auto Document = StackAllocator.New!SDLDocument(StackAllocator);
   Document.ParseDocumentFromString(`foo "bar" baz="qux"`, Context);
@@ -1078,7 +1078,7 @@ unittest
   scope(exit) System.Deallocate(Stack.Memory);
   auto StackAllocator = Wrap(Stack);
 
-  auto Context = ParsingContext("SDL Test 7", .Log);
+  auto Context = SDLParsingContext("SDL Test 7", .Log);
 
   auto Document = StackAllocator.New!SDLDocument(StackAllocator);
   auto Source = q"(
@@ -1110,7 +1110,7 @@ unittest
   scope(exit) System.Deallocate(Stack.Memory);
   auto StackAllocator = Wrap(Stack);
 
-  auto Context = ParsingContext("SDL Test 8", .Log);
+  auto Context = SDLParsingContext("SDL Test 8", .Log);
 
   auto Document = StackAllocator.New!SDLDocument(StackAllocator);
   auto Source = q"(
@@ -1151,7 +1151,7 @@ unittest
   scope(exit) System.Deallocate(Stack.Memory);
   auto StackAllocator = Wrap(Stack);
 
-  auto Context = ParsingContext("SDL Test 9", .Log);
+  auto Context = SDLParsingContext("SDL Test 9", .Log);
 
   auto Document = StackAllocator.New!SDLDocument(StackAllocator);
   Document.ParseDocumentFromString(`answer 42`, Context);
@@ -1164,7 +1164,7 @@ unittest
   assert(cast(int)Node.Values[0] == 42, Node.Values[0].NumberSource);
 }
 
-/// Parse document from file.
+// Parse document from file.
 unittest
 {
   void TheActualTest(SDLDocument Document)
@@ -1358,7 +1358,7 @@ unittest
 
   // TODO(Manu): Once we have WString => UString conversion, use the filename
   // as context.
-  auto Context = ParsingContext("Full", .Log);
+  auto Context = SDLParsingContext("Full", .Log);
   auto Document = StackAllocator.New!SDLDocument(StackAllocator);
 
   scope(exit) StackAllocator.Delete(Document);

--- a/code/krepel/serialization/sdlang.d
+++ b/code/krepel/serialization/sdlang.d
@@ -19,7 +19,7 @@ class SDLDocument
   IAllocator Allocator;
 
   /// The first node in the SDL document.
-  SDLNode FirstChild;
+  SDLNode* FirstChild;
 
   this(IAllocator Allocator)
   {
@@ -27,7 +27,7 @@ class SDLDocument
   }
 }
 
-class SDLNode
+struct SDLNode
 {
   /// The document this node belongs to.
   SDLDocument Document;
@@ -35,14 +35,14 @@ class SDLNode
   //
   // Siblings
   //
-  SDLNode Next;
-  SDLNode Previous;
+  SDLNode* Next;
+  SDLNode* Previous;
 
   //
   // Parents and Children
   //
-  SDLNode Parent;
-  SDLNode FirstChild;
+  SDLNode* Parent;
+  SDLNode* FirstChild;
 
   //
   // Node properties
@@ -406,7 +406,7 @@ bool ParseDocumentFromSource(SDLDocument Document, ref SourceData Source, ref Pa
 }
 
 bool ParseInnerNodes(SDLDocument Document, ref SourceData Source, ref ParsingContext Context,
-                     SDLNode* FirstNode)
+                     SDLNode** FirstNode)
 {
   if(FirstNode is null)
   {
@@ -419,8 +419,8 @@ bool ParseInnerNodes(SDLDocument Document, ref SourceData Source, ref ParsingCon
     return false;
   }
 
-  SDLNode PreviousNode = *FirstNode;
-  SDLNode NewNode;
+  SDLNode* PreviousNode = *FirstNode;
+  SDLNode* NewNode;
   while(Document.ParseNode(Source, Context, &NewNode))
   {
     PreviousNode.Next = NewNode;
@@ -504,7 +504,7 @@ bool ParseIdentifier(SDLDocument Document,
 bool ParseNode(SDLDocument Document,
                ref SourceData OriginalSource,
                ref ParsingContext Context,
-               SDLNode* OutNode)
+               SDLNode** OutNode)
 {
   auto Source = OriginalSource;
   Source.SkipWhiteSpaceAndComments(Context, Yes.ConsumeNewLine);

--- a/dev/build.d
+++ b/dev/build.d
@@ -699,6 +699,11 @@ int main(string[] Args)
     // Make a copy.
     auto Context = BaseBuildContext;
 
+    if(BaseBuildContext.Verbosity > 0)
+    {
+      logf("Build rule: %s", buildRuleName);
+    }
+
     final switch(Context.Platform)
     {
       case PlatformKind.Win32:

--- a/krepel.sublime-project
+++ b/krepel.sublime-project
@@ -29,7 +29,15 @@
       "variants":
       [
         {
-          "name": "Krepel, Build and Run Tests",
+          "name": "Krepel Tests, Build Only",
+
+          "windows":
+          {
+            "cmd": [ "${folder}\\build.bat", "krepel_tests_build_only" ]
+          }
+        },
+        {
+          "name": "Krepel Tests, Build and Run",
 
           "windows":
           {

--- a/krepel.sublime-project
+++ b/krepel.sublime-project
@@ -53,7 +53,7 @@
           }
         },
         {
-          "name": "Win32 Experiments, Build and Run Tests",
+          "name": "Win32 Experiments, Build and Run",
 
           "windows":
           {

--- a/krepel.sublime-project
+++ b/krepel.sublime-project
@@ -37,6 +37,14 @@
           }
         },
         {
+          "name": "Krepel Tests, Run Only",
+
+          "windows":
+          {
+            "cmd": [ "${folder}\\build.bat", "krepel_tests_run_only" ]
+          }
+        },
+        {
           "name": "Krepel Tests, Build and Run",
 
           "windows":


### PR DESCRIPTION
I've done a bit more than just add SDL convenience stuff, but it should be mostly straight forward.

Also, I branched off from `vulkan` because `master` was quite far behind, so that's why I want to merge back there first. We will have to do a bigger merge afterwards into `master`, so that you (@pampersrocker) can get these changes to your branch.
## Summary
- I've implemented a simple and not very effficient `SDLNodeIterator`, which can be conveniently used to access children by name. Note that you will still have to choose the index of the child to use since you can have multiple nodes of the same name on the same level. Check the unit tests for usage code.
- I've implemented a small and simple query language. I even made a spec in `code/krepel/serialization/Spec.md`
- I've generalized the `AutoHeapAllocator` to also at least support `StackMemory` and already used it in the unit tests in sdlang.d.
- The custom assert handler is now creationg a `new AssertError` everytime because otherwise the stack trace was wrong. I also added support for [detecting if a debugger is attached](https://msdn.microsoft.com/en-us/library/windows/desktop/ms680345%28v=vs.85%29.aspx) and triggering a `DebugBreak()` if that's the case.
- I altered the `dev/build.d` script to show which rule it is executing beforehand. This way you will have more confirmation about what it is doing while waiting for it to compile, without raising the verbosity level to insanity :smile: 
